### PR TITLE
fix(KER-17): streamline env UI, scope auth test run, fix bug status buttons

### DIFF
--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -25,6 +25,7 @@ const RunSchema = z.object({
   intent: z.string().min(3).optional(),
   testId: z.string().uuid().optional(),
   destinationId: z.string().uuid().optional(),
+  authTest: z.boolean().optional(),
 });
 
 export function registerRunRoutes(
@@ -56,10 +57,11 @@ export function registerRunRoutes(
     const parsed = RunSchema.safeParse({ ...(req.body as Record<string, unknown>), projectId });
     if (!parsed.success) { reply.code(400).send({ error: "invalid payload" }); return; }
 
-    const { environmentId, testId, destinationId } = parsed.data;
+    const { environmentId, testId, destinationId, authTest } = parsed.data;
     let intent = parsed.data.intent;
     let context: string | undefined;
     let maxSteps: number | undefined;
+    if (authTest) maxSteps = 8;
 
     let dest: Awaited<ReturnType<StorageAdapter["getDestination"]>> = null;
     if (destinationId) {
@@ -89,7 +91,7 @@ export function registerRunRoutes(
       sourceLabel = title || String(dest.normalized_route ?? "");
       sourceType = "page";
     } else {
-      sourceLabel = intent.trim();
+      sourceLabel = authTest ? "Test auth" : intent.trim();
       if (sourceLabel.length > 500) sourceLabel = `${sourceLabel.slice(0, 497)}...`;
       sourceType = "adhoc";
     }
@@ -102,7 +104,7 @@ export function registerRunRoutes(
     const run = await storage.createTestRun({
       project_id: projectId, environment_id: environmentId,
       test_id: testId ?? null, destination_id: destinationId ?? null,
-      trigger_type: "manual", trigger_ref: "dashboard",
+      trigger_type: "manual", trigger_ref: authTest ? "auth_test" : "dashboard",
       // The job has only been enqueued here; worker flips this to `running`.
       status: "queued", started_at: new Date().toISOString(),
       source_type: sourceType,

--- a/apps/web/src/pages/Environments.tsx
+++ b/apps/web/src/pages/Environments.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Globe,
   Code,
@@ -13,6 +14,7 @@ import {
   Key,
   LockKey,
   Info,
+  Play,
 } from "@phosphor-icons/react";
 import type { Icon } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
@@ -28,14 +30,13 @@ import {
   Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle,
   DialogDescription, DialogFooter, DialogClose,
 } from "@/components/ui/dialog";
-import { Separator } from "@/components/ui/separator";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { cn } from "@/lib/utils";
 import { useProject } from "@/lib/projectContext";
 import {
   fetchEnvironments, createEnvironment, deleteEnvironment,
-  fetchAuth, saveAuth, updateEnvironment,
+  fetchAuth, saveAuth, updateEnvironment, runAuthTest,
 } from "@/projectApi";
 
 const AUTH_MODES: readonly {
@@ -277,6 +278,7 @@ type Env = { id: string; name: string; base_url: string; is_default: boolean };
 
 export const Environments: React.FC = () => {
   const { currentProjectId } = useProject();
+  const navigate = useNavigate();
 
   const [envs, setEnvs] = React.useState<Env[]>([]);
   const [expandedEnvId, setExpandedEnvId] = React.useState<string | null>(null);
@@ -285,8 +287,6 @@ export const Environments: React.FC = () => {
   // Env edit state
   const [editName, setEditName] = React.useState("");
   const [editUrl, setEditUrl] = React.useState("");
-  const [savingEnv, setSavingEnv] = React.useState(false);
-  const [envStatus, setEnvStatus] = React.useState("");
 
   // Create form
   const [createOpen, setCreateOpen] = React.useState(false);
@@ -302,8 +302,11 @@ export const Environments: React.FC = () => {
   const [authJson, setAuthJson] = React.useState("{}");
   const [uiForm, setUiForm] = React.useState<UiAuthForm>(DEFAULT_UI_FORM);
   const [tokenForm, setTokenForm] = React.useState<TokenProviderForm>(DEFAULT_TOKEN_FORM);
-  const [authSaving, setAuthSaving] = React.useState(false);
-  const [authStatus, setAuthStatus] = React.useState("");
+
+  // Unified footer state
+  const [saving, setSaving] = React.useState(false);
+  const [saveStatus, setSaveStatus] = React.useState("");
+  const [testingAuth, setTestingAuth] = React.useState(false);
 
   React.useEffect(() => {
     if (!currentProjectId) return;
@@ -330,16 +333,14 @@ export const Environments: React.FC = () => {
     setExpandedEnvId(env.id);
     setEditName(env.name);
     setEditUrl(env.base_url);
-    setEnvStatus("");
-    setAuthStatus("");
+    setSaveStatus("");
     if (!currentProjectId) return;
     try {
       const { auth } = await fetchAuth(currentProjectId, env.id);
       if (auth) {
         const cfg = auth.config_json || {};
-        // Map tokenProvider mode to clerk/supabase UI mode
         if (auth.mode === "tokenProvider" && cfg.tokenProvider?.type) {
-          setAuthMode(cfg.tokenProvider.type); // "clerk" or "supabase"
+          setAuthMode(cfg.tokenProvider.type);
         } else {
           setAuthMode(auth.mode || "none");
         }
@@ -373,12 +374,11 @@ export const Environments: React.FC = () => {
       setExpandedEnvId(res.environment.id);
       setEditName(res.environment.name);
       setEditUrl(res.environment.base_url);
-      setEnvStatus("");
+      setSaveStatus("");
       setAuthMode("none");
       setAuthJson("{}");
       setUiForm(DEFAULT_UI_FORM);
       setTokenForm(DEFAULT_TOKEN_FORM);
-      setAuthStatus("");
       setCreateOpen(false);
       setNewName("");
       setNewUrl("");
@@ -395,33 +395,18 @@ export const Environments: React.FC = () => {
     setDeleteTarget(null);
   }
 
-  async function handleSaveEnv() {
+  async function handleSave() {
     if (!currentProjectId || !expandedEnvId) return;
     const name = editName.trim();
     const url = editUrl.trim();
     if (!name || !url) return;
-    setSavingEnv(true);
-    setEnvStatus("");
+    setSaving(true);
+    setSaveStatus("");
     try {
-      const res = await updateEnvironment(currentProjectId, expandedEnvId, {
-        name,
-        baseUrl: url,
-      });
+      const res = await updateEnvironment(currentProjectId, expandedEnvId, { name, baseUrl: url });
       const updated: Env = res.environment;
       setEnvs((prev) => prev.map((e) => (e.id === updated.id ? updated : e)));
-      setEnvStatus("Saved.");
-    } catch {
-      setEnvStatus("Save failed.");
-    } finally {
-      setSavingEnv(false);
-    }
-  }
 
-  async function handleSaveAuth() {
-    if (!currentProjectId || !expandedEnvId) return;
-    setAuthSaving(true);
-    setAuthStatus("");
-    try {
       let config: Record<string, any>;
       let mode = authMode;
       if (authMode === "none") {
@@ -435,11 +420,22 @@ export const Environments: React.FC = () => {
         config = JSON.parse(authJson);
       }
       await saveAuth(currentProjectId, expandedEnvId, mode, config);
-      setAuthStatus("Saved.");
+      setSaveStatus("Saved.");
     } catch (e: any) {
-      setAuthStatus(e?.message?.includes("Save failed") ? "Save failed." : "Invalid JSON.");
+      setSaveStatus(e?.message?.includes("Save failed") ? "Save failed." : "Save failed.");
     } finally {
-      setAuthSaving(false);
+      setSaving(false);
+    }
+  }
+
+  async function handleTestAuth() {
+    if (!currentProjectId || !expandedEnvId) return;
+    setTestingAuth(true);
+    try {
+      const res = await runAuthTest(currentProjectId, expandedEnvId);
+      navigate(`/runs/${res.runId}`);
+    } finally {
+      setTestingAuth(false);
     }
   }
 
@@ -643,27 +639,7 @@ export const Environments: React.FC = () => {
                             className="font-mono"
                           />
                         </div>
-                        <div className="flex items-center gap-3 pt-1">
-                          <Button
-                            size="sm"
-                            onClick={handleSaveEnv}
-                            loading={savingEnv}
-                            disabled={!editName.trim() || !editUrl.trim()}
-                          >
-                            Save environment
-                          </Button>
-                          {envStatus && (
-                            <span className={cn(
-                              "text-[12px]",
-                              envStatus === "Saved." ? "text-status-pass" : "text-destructive",
-                            )}>
-                              {envStatus}
-                            </span>
-                          )}
-                        </div>
                       </section>
-
-                      <Separator />
 
                       {/* Auth configuration */}
                       <section className="space-y-4">
@@ -876,24 +852,39 @@ export const Environments: React.FC = () => {
                           </div>
                         )}
 
-                        <div className="flex items-center gap-3 pt-1">
-                          <Button
-                            size="sm"
-                            onClick={handleSaveAuth}
-                            loading={authSaving}
-                          >
-                            {authMode === "none" ? "Save (no auth)" : "Save auth config"}
-                          </Button>
-                          {authStatus && (
-                            <span className={cn(
-                              "text-[12px]",
-                              authStatus === "Saved." ? "text-status-pass" : "text-destructive",
-                            )}>
-                              {authStatus}
-                            </span>
-                          )}
-                        </div>
                       </section>
+                    </div>
+
+                    {/* Sticky footer */}
+                    <div className="flex-shrink-0 border-t border-border px-6 py-3 flex items-center gap-3 bg-surface-2 dark:bg-surface-3">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleSave}
+                        loading={saving}
+                        disabled={!editName.trim() || !editUrl.trim()}
+                      >
+                        Save config
+                      </Button>
+                      {authMode !== "none" && (
+                        <Button
+                          size="sm"
+                          onClick={handleTestAuth}
+                          loading={testingAuth}
+                          disabled={saving}
+                        >
+                          <Play className="h-3.5 w-3.5" />
+                          Test auth
+                        </Button>
+                      )}
+                      {saveStatus && (
+                        <span className={cn(
+                          "text-[12px]",
+                          saveStatus === "Saved." ? "text-status-pass" : "text-destructive",
+                        )}>
+                          {saveStatus}
+                        </span>
+                      )}
                     </div>
                   </div>
                 ) : (

--- a/apps/web/src/pages/RunDetail.tsx
+++ b/apps/web/src/pages/RunDetail.tsx
@@ -1992,18 +1992,22 @@ function BugCard({
   const reportedIso = dbBug?.reported_at ?? run.completed_at ?? run.started_at ?? "";
   const isExpanded = forceExpanded || expanded;
 
+  const [bugStatus, setBugStatus] = React.useState<string | undefined>(dbBug?.status);
+  const isOpen = !bugStatus || bugStatus === "open" || bugStatus === "in_progress";
+
   async function resolveIssue() {
-    if (!projectId || !dbBug?.id) return;
+    if (!projectId || !dbBug?.id || !isOpen) return;
     setBusy(true);
     try {
       await patchProjectBug(projectId, dbBug.id, { status: "resolved" });
+      setBugStatus("resolved");
     } finally {
       setBusy(false);
     }
   }
 
   async function ignoreIssue() {
-    if (!projectId || !dbBug?.id) return;
+    if (!projectId || !dbBug?.id || !isOpen) return;
     setBusy(true);
     try {
       await patchProjectBug(projectId, dbBug.id, { status: "wont_fix" });
@@ -2014,6 +2018,7 @@ function BugCard({
         content: `${bodyForMemory}\n\n${bug.url ? `URL: ${bug.url}` : ""}`.trim(),
         confidence: 100,
       });
+      setBugStatus("wont_fix");
     } finally {
       setBusy(false);
     }
@@ -2040,12 +2045,12 @@ function BugCard({
           <StatusDot status={BUG_SEVERITY_STATUS_DOT[bug.severity] ?? "stale"} />
           <span className="text-[13px] font-medium text-foreground truncate flex-1 min-w-0">{displayName}</span>
           <BugCategoryTag category={category} />
-          {dbBug?.status && (
+          {bugStatus && (
             <Badge
-              variant={RUN_BUG_STATUS_BADGE[dbBug.status] ?? "neutral"}
+              variant={RUN_BUG_STATUS_BADGE[bugStatus] ?? "neutral"}
               className="capitalize flex-shrink-0 text-[10px]"
             >
-              {dbBug.status.replace("_", " ")}
+              {bugStatus.replace("_", " ")}
             </Badge>
           )}
           <span className="text-[11px] font-mono text-muted-foreground/50 flex-shrink-0 tabular-nums">
@@ -2127,7 +2132,7 @@ function BugCard({
               {reportedIso ? new Date(reportedIso).toLocaleString() : "—"}
             </span>
             <div className="flex flex-wrap items-center gap-2 ml-auto">
-              {projectId && dbBug?.id && (
+              {projectId && dbBug?.id && isOpen && (
                 <>
                   <Button
                     size="sm"

--- a/apps/web/src/projectApi.ts
+++ b/apps/web/src/projectApi.ts
@@ -137,6 +137,17 @@ export async function runProjectTest(projectId: string, environmentId: string, i
   });
 }
 
+export async function runAuthTest(projectId: string, environmentId: string) {
+  return apiFetch(`${API_BASE}/api/projects/${projectId}/run`, {
+    method: "POST",
+    body: JSON.stringify({
+      environmentId,
+      authTest: true,
+      intent: "Log in using the configured credentials. Once you have successfully authenticated and can see the main app (not the login page), take a screenshot and stop immediately. Do not navigate to any other pages or perform any other actions. Your only goal is to confirm whether authentication succeeds.",
+    }),
+  });
+}
+
 export async function fetchRun(runId: string) {
   return apiFetch(`${API_BASE}/api/runs/${runId}`);
 }

--- a/apps/worker/src/runQueue.ts
+++ b/apps/worker/src/runQueue.ts
@@ -231,6 +231,7 @@ export function createRunWorker(
           maxSteps: data.maxSteps,
           recordVideo: data.recordVideo,
           videosDir: VIDEOS_DIR,
+          triggerRef: data.triggerRef,
           onStep: (step: any) => {
             void live.forwardStep(step);
             const at = typeof step?.at === "number" ? step.at : Date.now();

--- a/packages/engine/src/runOrchestrator.ts
+++ b/packages/engine/src/runOrchestrator.ts
@@ -43,6 +43,7 @@ export type RunJob = {
   maxSteps?: number;
   recordVideo?: boolean;
   videosDir?: string;
+  triggerRef?: string;
   onStep?: (step: RunStep) => void;
   onAgentPlan?: (items: AgentPlanItem[]) => void;
   onActivity?: (activity: { kind: "observe"; text: string; at: number }) => void;
@@ -235,8 +236,10 @@ export async function runOrchestratedJob(storage: StorageAdapter, job: RunJob): 
       netMonitor,
     );
 
-    // Skip all post-agent review work if the run was stopped by the user — return immediately.
+    // Skip all post-agent review work if the run was stopped by the user, or if this is
+    // an auth-test run (which only needs the navigator result, not bug-finding review).
     const wasStopped = agentResult.failReason === "Stopped by user";
+    const isAuthTest = job.triggerRef === "auth_test";
 
     // Capture the final page state for holistic review (uses clean screenshot from agent
     // if available; raw fallback only goes to holistic, not filmstrip, since filmstrip
@@ -262,7 +265,7 @@ export async function runOrchestratedJob(storage: StorageAdapter, job: RunJob): 
     const navigatorStatus = agentResult.status === "passed" ? "passed" : "failed";
 
     emitActivity("Running post-run review agents...");
-    const [{ bugs: holisticBugs }, { bugs: filmstripBugs }] = wasStopped
+    const [{ bugs: holisticBugs }, { bugs: filmstripBugs }] = wasStopped || isAuthTest
       ? [{ bugs: [] }, { bugs: [] }]
       : await Promise.all([
           runHolisticFlowReview(


### PR DESCRIPTION
## Summary

Five follow-up fixes bundled together:

1. **Unified environment form** — the two separate "Save environment" and "Save auth config" buttons are gone. The form is now one continuous layout with a sticky footer containing **Save config** (outline) and **Test auth** (primary/filled). Save config writes both the env settings and auth config in a single action.

2. **Scoped auth test run** — added `authTest: true` flag to the run API. When set: caps the run at 8 steps, labels it "Test auth" in the runs list, and sets `trigger_ref: "auth_test"` so the engine knows to skip the holistic and filmstrip review agents entirely. The intent is narrowly worded to stop immediately after confirming login — no exploration.

3. **Review agents skipped for auth tests** — `triggerRef` now flows from API → BullMQ job → engine's `RunJob`. The orchestrator checks `job.triggerRef === "auth_test"` alongside `wasStopped` to short-circuit post-run review.

4. **Bug status buttons fix** — `BugCard` now tracks `bugStatus` in local state, initialised from the DB value. After resolving or ignoring, status updates immediately and both buttons disappear (matching the main Issues page). Guards on `isOpen` prevent duplicate memory entries from repeated clicks.

5. **Closed PR #13** which had an earlier incomplete version of the auth test button.

## Test plan

- [ ] Environment screen: verify only one save action + sticky footer with both buttons
- [ ] Test auth with valid creds → navigates to run, run stops after login screenshot, no review agents fire
- [ ] Test auth with bad creds → run shows stuck on login page
- [ ] Auth mode = none → Test auth button not visible
- [ ] Run detail issues tab: click Mark as resolved → badge updates, both buttons disappear
- [ ] Click ignore bug → badge updates, no second memory entry created on re-click

Closes https://linear.app/kery-dev/issue/KER-17/fix-crawl