### PR TITLE
feat(KER-20): move crawl execution from API to worker via BullMQ

### DIFF
--- a/apps/api/src/routes/crawl.ts
+++ b/apps/api/src/routes/crawl.ts
@@ -1,7 +1,9 @@
 import { FastifyInstance } from "fastify";
 import { Pool } from "pg";
 import type { StorageAdapter } from "@kery/engine";
-import { executeCrawlRun, logger } from "@kery/engine";
+import { logger } from "@kery/engine";
+import type { Queue } from "bullmq";
+import type { CrawlJobData } from "../runQueue.js";
 import { ProjectIdParams, ProjectCrawlRunParams } from "./params.js";
 
 /** Runs left as `running` after crash / killed process are auto-failed so the UI can scan again. */
@@ -32,7 +34,7 @@ async function hasRunningCrawl(pool: Pool, projectId: string): Promise<boolean> 
   return !!rows[0];
 }
 
-export function registerCrawlRoutes(app: FastifyInstance, storage: StorageAdapter) {
+export function registerCrawlRoutes(app: FastifyInstance, storage: StorageAdapter, crawlQueue: Queue<CrawlJobData>) {
   const pool = storage.getPool() as Pool;
 
   app.post("/api/projects/:projectId/crawl", async (req, reply) => {
@@ -58,16 +60,10 @@ export function registerCrawlRoutes(app: FastifyInstance, storage: StorageAdapte
     const environmentId = envs[0]?.id;
     if (!environmentId) { reply.code(400).send({ error: "No crawlable environment configured." }); return; }
 
-    reply.send({ status: "started", message: "Crawl started" });
+    await crawlQueue.add("crawl", { projectId, environmentId, triggerType: "manual" } satisfies CrawlJobData);
+    logger.info({ projectId, environmentId }, "Crawl job enqueued");
 
-    (async () => {
-      try {
-        const { result } = await executeCrawlRun(storage, projectId, environmentId, "manual");
-        logger.info({ projectId, destinations: result.destinationsBuilt }, "Crawl complete");
-      } catch (err) {
-        logger.error({ err: String(err), projectId }, "Background crawl failed");
-      }
-    })();
+    reply.send({ status: "started", message: "Crawl started" });
   });
 
   app.post("/api/projects/:projectId/scan", async (req, reply) => {
@@ -95,16 +91,10 @@ export function registerCrawlRoutes(app: FastifyInstance, storage: StorageAdapte
     const environmentId = envs[0]?.id;
     if (!environmentId) { reply.code(400).send({ error: "Add an environment first." }); return; }
 
-    reply.send({ status: "scanning", message: "Scanning your app..." });
+    await crawlQueue.add("crawl", { projectId, environmentId, triggerType: "manual" } satisfies CrawlJobData);
+    logger.info({ projectId, environmentId }, "Scan job enqueued");
 
-    (async () => {
-      try {
-        const { result } = await executeCrawlRun(storage, projectId, environmentId, "manual");
-        logger.info({ projectId, pages: result.destinationsBuilt }, "Scan complete");
-      } catch (err) {
-        logger.error({ err: String(err), projectId }, "Scan failed");
-      }
-    })();
+    reply.send({ status: "scanning", message: "Scanning your app..." });
   });
 
   app.get("/api/projects/:projectId/scan/status", async (req, reply) => {

--- a/apps/api/src/runQueue.ts
+++ b/apps/api/src/runQueue.ts
@@ -2,6 +2,7 @@ import { Queue } from "bullmq";
 
 /** BullMQ forbids ':' in queue names (reserved for Redis Cluster key tags). */
 export const RUN_QUEUE_NAME = "kery-runs";
+export const CRAWL_QUEUE_NAME = "kery-crawls";
 
 export interface RunJobData {
   runId: string;
@@ -20,14 +21,29 @@ export interface RunJobData {
   triggerRef: string;
 }
 
-export function createRunQueue(redisUrl: string) {
+export interface CrawlJobData {
+  projectId: string;
+  environmentId: string;
+  triggerType: "manual" | "webhook" | "scheduled";
+}
+
+function parseRedisUrl(redisUrl: string) {
   const url = new URL(redisUrl);
-  const connection = {
+  return {
     host: url.hostname,
     port: Number(url.port) || 6379,
     password: url.password || undefined,
   };
+}
 
+export function createRunQueue(redisUrl: string) {
+  const connection = parseRedisUrl(redisUrl);
   const queue = new Queue(RUN_QUEUE_NAME, { connection });
+  return { queue, connection };
+}
+
+export function createCrawlQueue(redisUrl: string) {
+  const connection = parseRedisUrl(redisUrl);
+  const queue = new Queue<CrawlJobData>(CRAWL_QUEUE_NAME, { connection });
   return { queue, connection };
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -15,7 +15,7 @@ import { registerTestRoutes } from "./routes/tests.js";
 import { registerBugRoutes } from "./routes/bugs.js";
 import { registerSettingsRoutes, applyDbModelSettings, applyDbApiKeySettings } from "./routes/settings.js";
 import { Redis } from "ioredis";
-import { createRunQueue } from "./runQueue.js";
+import { createRunQueue, createCrawlQueue } from "./runQueue.js";
 import { withRunCorrelation } from "@kery/engine";
 
 // Initialize engine config from environment
@@ -39,8 +39,9 @@ initEngineConfig({
 const pool = initPool(config.databaseUrl);
 const storage = new PostgresAdapter(pool);
 
-// Initialize BullMQ queue (enqueue only — execution handled by the worker process)
+// Initialize BullMQ queues (enqueue only — execution handled by the worker process)
 const { queue: runQueue } = createRunQueue(config.redisUrl);
+const { queue: crawlQueue } = createCrawlQueue(config.redisUrl);
 /** Redis client for live snapshot reads and run stop signals. */
 const redis = new Redis(config.redisUrl, { maxRetriesPerRequest: null });
 
@@ -77,7 +78,7 @@ app.get("/health", async () => ({ status: "ok" }));
 // Register routes — pass storage adapter and run queue
 registerProjectRoutes(app, storage);
 registerRunRoutes(app, storage, runQueue, redis, config.redisUrl);
-registerCrawlRoutes(app, storage);
+registerCrawlRoutes(app, storage, crawlQueue);
 registerTestRoutes(app, storage);
 registerBugRoutes(app, storage);
 registerSettingsRoutes(app, storage);
@@ -109,6 +110,7 @@ try {
 async function shutdown() {
   console.log("Shutting down gracefully...");
   await runQueue.close();
+  await crawlQueue.close();
   await app.close();
   await pool.end();
   await redis.quit().catch(() => {});

--- a/apps/worker/src/crawlQueue.ts
+++ b/apps/worker/src/crawlQueue.ts
@@ -1,0 +1,54 @@
+import { Queue, Worker, Job } from "bullmq";
+import type { StorageAdapter } from "@kery/engine";
+import { executeCrawlRun, logger } from "@kery/engine";
+
+export const CRAWL_QUEUE_NAME = "kery-crawls";
+
+export interface CrawlJobData {
+  projectId: string;
+  environmentId: string;
+  triggerType: "manual" | "webhook" | "scheduled";
+}
+
+export function createCrawlQueue(redisUrl: string) {
+  const url = new URL(redisUrl);
+  const connection = {
+    host: url.hostname,
+    port: Number(url.port) || 6379,
+    password: url.password || undefined,
+  };
+  const queue = new Queue<CrawlJobData>(CRAWL_QUEUE_NAME, { connection });
+  return { queue, connection };
+}
+
+export function createCrawlWorker(
+  connection: { host: string; port: number; password?: string },
+  storage: StorageAdapter,
+) {
+  const worker = new Worker<CrawlJobData>(
+    CRAWL_QUEUE_NAME,
+    async (job: Job<CrawlJobData>) => {
+      const { projectId, environmentId, triggerType } = job.data;
+      logger.info({ projectId, environmentId }, "Crawl job started");
+      try {
+        const { result } = await executeCrawlRun(storage, projectId, environmentId, triggerType);
+        logger.info({ projectId, destinations: result.destinationsBuilt }, "Crawl job complete");
+      } catch (err) {
+        logger.error({ err: String(err), projectId }, "Crawl job failed");
+        throw err;
+      }
+    },
+    {
+      connection,
+      concurrency: 1,
+      removeOnComplete: { count: 20 },
+      removeOnFail: { count: 100 },
+    },
+  );
+
+  worker.on("failed", (job, err) => {
+    logger.error({ jobId: job?.id, projectId: job?.data?.projectId, err: String(err) }, "Crawl BullMQ job failed");
+  });
+
+  return worker;
+}

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -3,6 +3,7 @@ import { initEngineConfig, updateEngineConfig } from "@kery/engine";
 import { initPool, PostgresAdapter, decryptValue } from "@kery/db";
 import { Redis } from "ioredis";
 import { createRunQueue, createRunWorker } from "./runQueue.js";
+import { createCrawlQueue, createCrawlWorker } from "./crawlQueue.js";
 
 initEngineConfig({
   openaiApiKey: config.openaiApiKey,
@@ -61,6 +62,7 @@ try {
 }
 
 const { connection: redisConnection } = createRunQueue(config.redisUrl);
+const { connection: crawlRedisConnection } = createCrawlQueue(config.redisUrl);
 
 /** Shared Redis client for run stop signals (API sets key, worker polls). */
 const redis = new Redis(config.redisUrl, { maxRetriesPerRequest: null });
@@ -69,12 +71,14 @@ const redis = new Redis(config.redisUrl, { maxRetriesPerRequest: null });
 const redisPub = new Redis(config.redisUrl, { maxRetriesPerRequest: null });
 
 const runWorker = createRunWorker(redisConnection, storage, redis, redisPub);
+const crawlWorker = createCrawlWorker(crawlRedisConnection, storage);
 
 console.log("Kery worker started — waiting for jobs");
 
 async function shutdown() {
   console.log("Worker shutting down gracefully...");
   await runWorker.close();
+  await crawlWorker.close();
   await pool.end();
   await redis.quit().catch(() => {});
   await redisPub.quit().catch(() => {});


### PR DESCRIPTION
## Summary

- The API container previously ran Playwright crawls inline (fire-and-forget async IIFE), tying up the process with long-lived browser sessions alongside HTTP serving
- Added `CrawlJobData` type and `createCrawlQueue()` to both the API and worker apps
- API now enqueues a crawl job to the `kery-crawls` BullMQ queue and returns immediately
- New `apps/worker/src/crawlQueue.ts` implements `createCrawlWorker()`, which picks up jobs and calls `executeCrawlRun()` — the same function that ran inline before
- Worker entrypoint starts both the run worker and crawl worker; both shut down cleanly on SIGTERM/SIGINT

## Test plan

- [ ] Trigger a scan via the UI — confirm the API responds immediately and the crawl run record appears in the DB with `status = running`
- [ ] Confirm the worker log shows "Crawl job started" then "Crawl job complete"
- [ ] Confirm pages/routes appear in the UI after the crawl completes
- [ ] Trigger scan while one is running — confirm 409 response still works (status check happens in API before enqueue)
- [ ] Kill the worker mid-crawl — confirm the stale-run expiry logic marks it failed on next scan trigger

Closes https://linear.app/kery-dev/issue/KER-20/move-crawl-to-worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)