### PR TITLE
feat: bug triage flow — Mark for fix / Ignore + MCP nudge

### DIFF
--- a/apps/web/src/lib/bug-issue-display.ts
+++ b/apps/web/src/lib/bug-issue-display.ts
@@ -6,6 +6,30 @@ export const BUG_SEVERITY_STATUS_DOT: Record<string, string> = {
 };
 
 /**
+ * User-facing bug status labels.
+ * The DB stores 4 states (open/in_progress/resolved/wont_fix) which we
+ * surface as triage states: Needs review, To fix, Fixed, Ignored.
+ */
+export const BUG_STATUS_LABEL: Record<string, string> = {
+  open: "Needs review",
+  in_progress: "To fix",
+  resolved: "Fixed",
+  wont_fix: "Ignored",
+};
+
+export function bugStatusLabel(status: string | null | undefined): string {
+  if (!status) return BUG_STATUS_LABEL.open;
+  return BUG_STATUS_LABEL[status] ?? status.replace(/_/g, " ");
+}
+
+export const BUG_STATUS_BADGE: Record<string, "success" | "warning" | "neutral" | "destructive"> = {
+  open: "warning",
+  in_progress: "warning",
+  resolved: "success",
+  wont_fix: "neutral",
+};
+
+/**
  * Category label colors — text only (no border); Issues + Run detail.
  * Overview bug rows stay plain outline per Overview.tsx.
  */

--- a/apps/web/src/lib/export-issues-pdf.ts
+++ b/apps/web/src/lib/export-issues-pdf.ts
@@ -42,7 +42,7 @@ const SEV_COLOR: Record<string, RGB> = { high: C.high, medium: C.medium, low: C.
 const SEV_LABEL: Record<string, string> = { high: "HIGH", medium: "MED", low: "LOW" };
 const CAT_LABEL: Record<string, string> = { visual: "Visual", functional: "Functional", ux: "UX", other: "Other" };
 const STATUS_LABEL: Record<string, string> = {
-  open: "Open", in_progress: "In Progress", resolved: "Resolved", wont_fix: "Won't Fix",
+  open: "Needs review", in_progress: "To fix", resolved: "Fixed", wont_fix: "Ignored",
 };
 
 // ── Image helpers ─────────────────────────────────────────────────────────────

--- a/apps/web/src/pages/Bugs.tsx
+++ b/apps/web/src/pages/Bugs.tsx
@@ -25,7 +25,7 @@ import { EmptyState } from "@/components/empty-state";
 import { cn } from "@/lib/utils";
 import { SHOW_RUN_DEBUG } from "@/lib/debugFlag";
 import { formatReportedAt } from "@/lib/formatters";
-import { BUG_SEVERITY_STATUS_DOT, bugCategoryTagClass, projectBugDetailDescription } from "@/lib/bug-issue-display";
+import { BUG_SEVERITY_STATUS_DOT, BUG_STATUS_BADGE, bugCategoryTagClass, bugStatusLabel, projectBugDetailDescription } from "@/lib/bug-issue-display";
 import { BugCategoryTag } from "@/components/bug-category-tag";
 import { BugScreenshotZoomDialog } from "@/components/bug-screenshot-zoom-dialog";
 import { useProject } from "@/lib/projectContext";
@@ -93,12 +93,6 @@ const SEVERITY_VARIANT: Record<string, "destructive" | "warning" | "neutral"> = 
   low: "neutral",
 };
 
-const STATUS_VARIANT: Record<string, "success" | "warning" | "neutral" | "destructive"> = {
-  open: "warning",
-  in_progress: "warning",
-  resolved: "success",
-  wont_fix: "neutral",
-};
 
 // ─── Issue detail pane ────────────────────────────────────────────────────────
 
@@ -176,12 +170,12 @@ function IssueDetail({
             {bug.id && isOpen && (
               <Button
                 size="sm"
-                variant="outline"
+                variant="default"
                 className="h-7 px-3 text-[11px]"
                 disabled={actionBusy === bug.id}
                 onClick={onResolve}
               >
-                Mark as resolved
+                Mark for fix
               </Button>
             )}
             {bug.id && isOpen && (
@@ -192,7 +186,7 @@ function IssueDetail({
                 disabled={actionBusy === bug.id}
                 onClick={onIgnore}
               >
-                Ignore bug
+                Ignore
               </Button>
             )}
             {bug.id && (
@@ -259,8 +253,8 @@ function IssueDetail({
               <div className="space-y-2.5">
                 <div className="flex flex-wrap items-center gap-1.5">
                   <BugCategoryTag category={bug.category} />
-                  <Badge variant={STATUS_VARIANT[bug.status] ?? "neutral"} className="capitalize text-[10px]">
-                    {bug.status.replace("_", " ")}
+                  <Badge variant={BUG_STATUS_BADGE[bug.status] ?? "neutral"} className="text-[10px]">
+                    {bugStatusLabel(bug.status)}
                   </Badge>
                   {bug.test_name && (
                     <Badge variant="outline" className="text-[10px]">
@@ -372,14 +366,30 @@ export const Bugs: React.FC = () => {
     }
   }
 
-  async function resolveBug(bug: BugRecord) {
+  async function markBugForFix(bug: BugRecord) {
     if (!currentProjectId || !bug.id) return;
     setActionBusy(bug.id);
     try {
-      await patchProjectBug(currentProjectId, bug.id, { status: "resolved" });
+      await patchProjectBug(currentProjectId, bug.id, { status: "in_progress" });
       await load();
     } finally {
       setActionBusy(null);
+    }
+  }
+
+  const [bulkBusy, setBulkBusy] = React.useState(false);
+  async function markAllForFix(bugsToMark: BugRecord[]) {
+    if (!currentProjectId || bugsToMark.length === 0) return;
+    setBulkBusy(true);
+    try {
+      await Promise.all(
+        bugsToMark
+          .filter((b) => b.id && b.status === "open")
+          .map((b) => patchProjectBug(currentProjectId, b.id!, { status: "in_progress" })),
+      );
+      await load();
+    } finally {
+      setBulkBusy(false);
     }
   }
 
@@ -571,6 +581,27 @@ export const Bugs: React.FC = () => {
               </span>
             </div>
 
+            {/* Triage banner — only when there are untriaged bugs in current filter */}
+            {(() => {
+              const untriaged = filteredBugs.filter((b) => b.status === "open");
+              if (untriaged.length === 0) return null;
+              return (
+                <div className="flex items-center gap-2 border-b border-border bg-primary/10 px-3 py-2 flex-shrink-0">
+                  <span className="text-[11px] text-foreground flex-1 min-w-0">
+                    <span className="font-medium">{untriaged.length}</span> bug{untriaged.length === 1 ? "" : "s"} need review
+                  </span>
+                  <button
+                    type="button"
+                    className="text-[11px] font-medium text-foreground underline-offset-2 hover:underline disabled:opacity-50"
+                    disabled={bulkBusy}
+                    onClick={() => markAllForFix(untriaged)}
+                  >
+                    Mark all for fix
+                  </button>
+                </div>
+              );
+            })()}
+
             {/* scrollable list */}
             <div className="flex-1 min-h-0 overflow-y-auto px-2 py-2 space-y-1.5">
               {filteredBugs.length === 0 ? (
@@ -613,10 +644,10 @@ export const Bugs: React.FC = () => {
                               <div className="mt-1.5 flex flex-wrap items-center gap-1">
                                 <BugCategoryTag category={bug.category} />
                                 <Badge
-                                  variant={STATUS_VARIANT[bug.status] ?? "neutral"}
-                                  className="capitalize text-[10px]"
+                                  variant={BUG_STATUS_BADGE[bug.status] ?? "neutral"}
+                                  className="text-[10px]"
                                 >
-                                  {bug.status.replace("_", " ")}
+                                  {bugStatusLabel(bug.status)}
                                 </Badge>
                                 <span className="ml-auto text-[10px] font-mono text-muted-foreground/50">
                                   {formatReportedAt(reportedIso)}
@@ -649,7 +680,7 @@ export const Bugs: React.FC = () => {
                 actionBusy={actionBusy}
                 showRaw={showRawId === selectedId}
                 onToggleRaw={() => setShowRawId(showRawId === selectedId ? null : selectedId)}
-                onResolve={() => resolveBug(selectedBug)}
+                onResolve={() => markBugForFix(selectedBug)}
                 onIgnore={() => ignoreBug(selectedBug)}
                 onDelete={() => setDeletePrompt({ kind: "one", bug: selectedBug })}
                 onViewRun={() => navigate(`/runs/${selectedBug.run_id ?? selectedBug.runId}`)}

--- a/apps/web/src/pages/Bugs.tsx
+++ b/apps/web/src/pages/Bugs.tsx
@@ -257,53 +257,19 @@ function IssueDetail({
             </section>
           )}
 
-          {/* Additional info */}
-          {hasContext && (
+          {bug.url && (
             <section className="border-t border-border pt-4">
-              <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50 mb-3">
-                Additional info
-              </p>
-              <div className="space-y-2.5">
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <BugCategoryTag category={bug.category} />
-                  <Badge variant={BUG_STATUS_BADGE[bug.status] ?? "neutral"} className="text-[10px]">
-                    {bugStatusLabel(bug.status)}
-                  </Badge>
-                  {bug.test_name && (
-                    <Badge variant="outline" className="text-[10px]">
-                      {bug.test_name}
-                    </Badge>
-                  )}
-                </div>
-                {bug.environment && (
-                  <div className="flex items-center gap-2">
-                    <ComputerTower className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/40" />
-                    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/40 w-20 shrink-0">Environment</span>
-                    <span className="text-[12px] text-muted-foreground">{bug.environment}</span>
-                  </div>
-                )}
-                {reportedDate && (
-                  <div className="flex items-center gap-2">
-                    <Calendar className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/40" />
-                    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/40 w-20 shrink-0">Detected</span>
-                    <span className="text-[12px] font-mono text-muted-foreground">{new Date(reportedDate).toLocaleString()}</span>
-                  </div>
-                )}
-                {bug.url && (
-                  <div className="flex items-start gap-2 min-w-0">
-                    <Globe className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/40 mt-0.5" />
-                    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/40 w-20 shrink-0 mt-0.5">URL</span>
-                    <a
-                      href={bug.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 min-w-0 text-[12px] font-mono text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      <span className="truncate">{bug.url}</span>
-                      <ArrowSquareOut className="h-3 w-3 flex-shrink-0 opacity-50" aria-hidden="true" />
-                    </a>
-                  </div>
-                )}
+              <div className="flex items-start gap-2 min-w-0">
+                <Globe className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/40 mt-0.5" />
+                <a
+                  href={bug.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 min-w-0 text-[12px] font-mono text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <span className="truncate">{bug.url}</span>
+                  <ArrowSquareOut className="h-3 w-3 flex-shrink-0 opacity-50" aria-hidden="true" />
+                </a>
               </div>
             </section>
           )}

--- a/apps/web/src/pages/Bugs.tsx
+++ b/apps/web/src/pages/Bugs.tsx
@@ -103,6 +103,7 @@ function IssueDetail({
   onToggleRaw,
   onResolve,
   onIgnore,
+  onUndo,
   onDelete,
   onViewRun,
 }: {
@@ -112,6 +113,7 @@ function IssueDetail({
   onToggleRaw: () => void;
   onResolve: () => void;
   onIgnore: () => void;
+  onUndo: () => void;
   onDelete: () => void;
   onViewRun: () => void;
 }) {
@@ -121,7 +123,7 @@ function IssueDetail({
   const legacy = screenshotRefToSrc(bug.screenshot_base64 ?? bug.screenshotBase64 ?? undefined);
   const screenshotSrc = fileUrl ?? legacy;
   const reportedDate = bug.reportedAt ?? bug.reported_at;
-  const isOpen = bug.status === "open" || bug.status === "in_progress";
+  const isOpen = bug.status === "open";
 
   const hasContext = !!(bug.environment || reportedDate || bug.url || bug.category || bug.status || bug.test_name);
 
@@ -168,25 +170,36 @@ function IssueDetail({
               View Run <ArrowSquareOut className="h-3 w-3" />
             </Button>
             {bug.id && isOpen && (
-              <Button
-                size="sm"
-                variant="default"
-                className="h-7 px-3 text-[11px]"
-                disabled={actionBusy === bug.id}
-                onClick={onResolve}
-              >
-                Mark for fix
-              </Button>
+              <>
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="h-7 px-3 text-[11px]"
+                  disabled={actionBusy === bug.id}
+                  onClick={onResolve}
+                >
+                  Mark for fix
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 px-3 text-[11px]"
+                  disabled={actionBusy === bug.id}
+                  onClick={onIgnore}
+                >
+                  Ignore
+                </Button>
+              </>
             )}
-            {bug.id && isOpen && (
+            {bug.id && !isOpen && (
               <Button
                 size="sm"
                 variant="outline"
                 className="h-7 px-3 text-[11px]"
                 disabled={actionBusy === bug.id}
-                onClick={onIgnore}
+                onClick={onUndo}
               >
-                Ignore
+                Undo
               </Button>
             )}
             {bug.id && (
@@ -371,6 +384,17 @@ export const Bugs: React.FC = () => {
     setActionBusy(bug.id);
     try {
       await patchProjectBug(currentProjectId, bug.id, { status: "in_progress" });
+      await load();
+    } finally {
+      setActionBusy(null);
+    }
+  }
+
+  async function undoBugTriage(bug: BugRecord) {
+    if (!currentProjectId || !bug.id) return;
+    setActionBusy(bug.id);
+    try {
+      await patchProjectBug(currentProjectId, bug.id, { status: "open" });
       await load();
     } finally {
       setActionBusy(null);
@@ -682,6 +706,7 @@ export const Bugs: React.FC = () => {
                 onToggleRaw={() => setShowRawId(showRawId === selectedId ? null : selectedId)}
                 onResolve={() => markBugForFix(selectedBug)}
                 onIgnore={() => ignoreBug(selectedBug)}
+                onUndo={() => undoBugTriage(selectedBug)}
                 onDelete={() => setDeletePrompt({ kind: "one", bug: selectedBug })}
                 onViewRun={() => navigate(`/runs/${selectedBug.run_id ?? selectedBug.runId}`)}
               />

--- a/apps/web/src/pages/FlowDetail.tsx
+++ b/apps/web/src/pages/FlowDetail.tsx
@@ -41,7 +41,7 @@ import {
   updateTest,
   patchProjectBug,
 } from "@/projectApi";
-import { BUG_SEVERITY_STATUS_DOT } from "@/lib/bug-issue-display";
+import { BUG_SEVERITY_STATUS_DOT, BUG_STATUS_BADGE, bugStatusLabel } from "@/lib/bug-issue-display";
 import { runScreenshotFileUrl } from "@/lib/apiAssets";
 import { BugScreenshotZoomDialog } from "@/components/bug-screenshot-zoom-dialog";
 import type { BugRecord } from "@/pages/Bugs";
@@ -314,9 +314,6 @@ export function FlowDetail() {
                     const isExpanded = expandedBugId === id;
                     const reportedIso = bug.reported_at ?? bug.reportedAt ?? "";
                     const SEVERITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
-                    const STATUS_VARIANT: Record<string, "success" | "warning" | "neutral" | "destructive"> = {
-                      open: "warning", in_progress: "warning", resolved: "success", wont_fix: "neutral",
-                    };
                     return (
                       <div
                         key={id}
@@ -335,8 +332,8 @@ export function FlowDetail() {
                             {bug.name}
                           </span>
                           <BugCategoryTag category={bug.category} />
-                          <Badge variant={STATUS_VARIANT[bug.status] ?? "neutral"} className="capitalize flex-shrink-0">
-                            {bug.status.replace("_", " ")}
+                          <Badge variant={BUG_STATUS_BADGE[bug.status] ?? "neutral"} className="flex-shrink-0">
+                            {bugStatusLabel(bug.status)}
                           </Badge>
                           <span className="text-[11px] font-mono text-muted-foreground/50 flex-shrink-0">
                             {reportedIso ? new Date(reportedIso).toLocaleDateString() : ""}
@@ -382,22 +379,22 @@ export function FlowDetail() {
                                 </a>
                               )}
                               <div className="flex flex-wrap items-center gap-2 ml-auto">
-                                {bug.id && (bug.status === "open" || bug.status === "in_progress") && (
+                                {bug.id && bug.status === "open" && (
                                   <Button
                                     size="sm"
-                                    variant="outline"
+                                    variant="default"
                                     className="h-7 text-[11px]"
                                     disabled={bugActionBusy === bug.id}
                                     onClick={async (e) => {
                                       e.stopPropagation();
                                       if (!currentProjectId || !bug.id) return;
                                       setBugActionBusy(bug.id);
-                                      await patchProjectBug(currentProjectId, bug.id, { status: "resolved" }).catch(() => {});
+                                      await patchProjectBug(currentProjectId, bug.id, { status: "in_progress" }).catch(() => {});
                                       await load();
                                       setBugActionBusy(null);
                                     }}
                                   >
-                                    Resolve
+                                    Mark for fix
                                   </Button>
                                 )}
                                 <Button

--- a/apps/web/src/pages/PageDetail.tsx
+++ b/apps/web/src/pages/PageDetail.tsx
@@ -348,8 +348,8 @@ export function PageDetail() {
                           <span className="text-[13px] font-medium text-foreground truncate flex-1 min-w-0">
                             {issue.name}
                           </span>
-                          <Badge variant={issue.status === "resolved" ? "success" : issue.status === "wont_fix" ? "neutral" : "warning"} className="capitalize text-[11px]">
-                            {issue.status.replace("_", " ")}
+                          <Badge variant={issue.status === "resolved" ? "success" : issue.status === "wont_fix" ? "neutral" : "warning"} className="text-[11px]">
+                            {issue.status === "open" ? "Needs review" : issue.status === "in_progress" ? "To fix" : issue.status === "resolved" ? "Fixed" : "Ignored"}
                           </Badge>
                           {reportedAt && (
                             <span className="text-[11px] font-mono text-muted-foreground/50 flex-shrink-0">

--- a/apps/web/src/pages/RunDetail.tsx
+++ b/apps/web/src/pages/RunDetail.tsx
@@ -2085,6 +2085,18 @@ function BugCard({
     }
   }
 
+  async function undoTriage() {
+    if (!projectId || !dbBug?.id) return;
+    setBusy(true);
+    try {
+      await patchProjectBug(projectId, dbBug.id, { status: "open" });
+      setBugStatus("open");
+      await onRefreshBugs?.();
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div
       className={cn(
@@ -2142,26 +2154,40 @@ function BugCard({
                 <h2 className="min-w-0 flex-1 text-[15px] font-semibold text-foreground leading-snug truncate">
                   {displayName}
                 </h2>
-                {projectId && dbBug?.id && isOpen && (
+                {projectId && dbBug?.id && (
                   <div className="flex items-center gap-1.5 flex-shrink-0">
-                    <Button
-                      size="sm"
-                      variant="default"
-                      className="h-7 px-3 text-[11px]"
-                      disabled={busy}
-                      onClick={(e) => { e.stopPropagation(); markForFix(); }}
-                    >
-                      Mark for fix
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-7 px-3 text-[11px]"
-                      disabled={busy}
-                      onClick={(e) => { e.stopPropagation(); ignoreIssue(); }}
-                    >
-                      Ignore
-                    </Button>
+                    {bugStatus === "open" || bugStatus == null ? (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="default"
+                          className="h-7 px-3 text-[11px]"
+                          disabled={busy}
+                          onClick={(e) => { e.stopPropagation(); markForFix(); }}
+                        >
+                          Mark for fix
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 px-3 text-[11px]"
+                          disabled={busy}
+                          onClick={(e) => { e.stopPropagation(); ignoreIssue(); }}
+                        >
+                          Ignore
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 px-3 text-[11px]"
+                        disabled={busy}
+                        onClick={(e) => { e.stopPropagation(); undoTriage(); }}
+                      >
+                        Undo
+                      </Button>
+                    )}
                   </div>
                 )}
               </div>
@@ -2337,7 +2363,7 @@ function BugCard({
               {reportedIso ? new Date(reportedIso).toLocaleString() : "—"}
             </span>
             <div className="flex flex-wrap items-center gap-2 ml-auto">
-              {projectId && dbBug?.id && isOpen && (
+              {projectId && dbBug?.id && (bugStatus === "open" || bugStatus == null) && (
                 <>
                   <Button
                     size="sm"
@@ -2364,6 +2390,17 @@ function BugCard({
                     Ignore
                   </Button>
                 </>
+              )}
+              {projectId && dbBug?.id && bugStatus && bugStatus !== "open" && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-[11px]"
+                  disabled={busy}
+                  onClick={(e) => { e.stopPropagation(); undoTriage(); }}
+                >
+                  Undo
+                </Button>
               )}
             </div>
           </div>

--- a/apps/web/src/pages/RunDetail.tsx
+++ b/apps/web/src/pages/RunDetail.tsx
@@ -2222,64 +2222,14 @@ function BugCard({
               </div>
             )}
 
-            <div className="px-6 py-5 space-y-4">
-              {/* Description */}
-              {detail && (
-                <section>
-                  <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50 mb-2">
-                    Description
-                  </p>
-                  <p className="text-[13px] text-foreground whitespace-pre-wrap leading-relaxed">{detail}</p>
-                </section>
-              )}
-
-              {/* Additional info */}
-              <section className="border-t border-border pt-4">
-                <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50 mb-3">
-                  Additional info
+            {detail && (
+              <div className="px-6 py-5">
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50 mb-2">
+                  Description
                 </p>
-                <div className="space-y-2.5">
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <BugCategoryTag category={category} />
-                    {dbBug?.status && (
-                      <Badge variant={BUG_STATUS_BADGE[dbBug.status] ?? "neutral"} className="text-[10px]">
-                        {bugStatusLabel(dbBug.status)}
-                      </Badge>
-                    )}
-                  </div>
-                  {run.environment && (
-                    <div className="flex items-center gap-2">
-                      <ComputerTower className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/40" />
-                      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/40 w-20 shrink-0">Environment</span>
-                      <span className="text-[12px] text-muted-foreground">{run.environment}</span>
-                    </div>
-                  )}
-                  {reportedIso && (
-                    <div className="flex items-center gap-2">
-                      <Calendar className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/40" />
-                      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/40 w-20 shrink-0">Detected</span>
-                      <span className="text-[12px] font-mono text-muted-foreground">{new Date(reportedIso).toLocaleString()}</span>
-                    </div>
-                  )}
-                  {bug.url && (
-                    <div className="flex items-start gap-2 min-w-0">
-                      <Globe className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/40 mt-0.5" />
-                      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/40 w-20 shrink-0 mt-0.5">URL</span>
-                      <a
-                        href={bug.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 min-w-0 text-[12px] font-mono text-muted-foreground hover:text-foreground transition-colors"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <span className="truncate">{bug.url}</span>
-                        <ArrowSquareOut className="h-3 w-3 flex-shrink-0 opacity-50" />
-                      </a>
-                    </div>
-                  )}
-                </div>
-              </section>
-            </div>
+                <p className="text-[13px] text-foreground whitespace-pre-wrap leading-relaxed">{detail}</p>
+              </div>
+            )}
           </div>
         );
       })()}

--- a/apps/web/src/pages/RunDetail.tsx
+++ b/apps/web/src/pages/RunDetail.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/lib/formatters";
 import {
   BUG_SEVERITY_STATUS_DOT,
+  BUG_STATUS_BADGE,
+  bugStatusLabel,
   runJsonBugDisplayName,
   runJsonBugDetailDescription,
 } from "@/lib/bug-issue-display";
@@ -228,13 +230,6 @@ function liveUiFromRun(run: Run): {
 }
 
 // --- Helpers ---
-
-const RUN_BUG_STATUS_BADGE: Record<string, "success" | "warning" | "neutral" | "destructive"> = {
-  open: "warning",
-  in_progress: "warning",
-  resolved: "success",
-  wont_fix: "neutral",
-};
 
 /** Vision frame for this step: file ref or legacy inline base64. */
 function visionImageRefForStep(llmCalls: LLMCallRecord[], stepIndex: number, runId: string): string | undefined {
@@ -935,6 +930,7 @@ export const RunDetail: React.FC = () => {
               bugsFound={bugsFound}
               runBugs={runBugs}
               projectId={run.project_id ?? undefined}
+              onRefreshBugs={() => fetchRunBugs(run.id).then((r: any) => setRunBugs(r.bugs ?? []))}
             />
           </TabsContent>
 
@@ -1848,6 +1844,49 @@ function GalleryTab({ groups }: { groups: Record<string, GalleryShot[]> }) {
 }
 
 // ============================================================
+// Run triage banner — appears above issue list when bugs need review
+// ============================================================
+
+function RunTriageBanner({
+  runBugs,
+  projectId,
+  onRefreshBugs,
+}: {
+  runBugs: { id?: string; status?: string }[];
+  projectId?: string;
+  onRefreshBugs?: () => Promise<void> | void;
+}) {
+  const [busy, setBusy] = React.useState(false);
+  const untriaged = runBugs.filter((b) => b.status === "open" && b.id);
+  if (untriaged.length === 0 || !projectId) return null;
+  return (
+    <div className="flex items-center gap-2 border-b border-border bg-primary/10 px-3 py-2 flex-shrink-0">
+      <span className="text-[11px] text-foreground flex-1 min-w-0">
+        <span className="font-medium">{untriaged.length}</span> bug{untriaged.length === 1 ? "" : "s"} need review
+      </span>
+      <button
+        type="button"
+        className="text-[11px] font-medium text-foreground underline-offset-2 hover:underline disabled:opacity-50"
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true);
+          try {
+            await Promise.all(
+              untriaged.map((b) => patchProjectBug(projectId, b.id!, { status: "in_progress" })),
+            );
+            await onRefreshBugs?.();
+          } finally {
+            setBusy(false);
+          }
+        }}
+      >
+        Mark all for fix
+      </button>
+    </div>
+  );
+}
+
+// ============================================================
 // Issues tab
 // ============================================================
 
@@ -1856,6 +1895,7 @@ function IssuesTab({
   bugsFound,
   runBugs,
   projectId,
+  onRefreshBugs,
 }: {
   run: Run;
   bugsFound: RunStep[];
@@ -1869,6 +1909,7 @@ function IssuesTab({
     reported_at?: string;
   }[];
   projectId?: string;
+  onRefreshBugs?: () => Promise<void> | void;
 }) {
   const [selectedIndex, setSelectedIndex] = React.useState(0);
   React.useEffect(() => {
@@ -1898,6 +1939,7 @@ function IssuesTab({
               <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Issues</span>
               <span className="text-[11px] font-mono text-muted-foreground/60">{bugsFound.length}</span>
             </div>
+            <RunTriageBanner runBugs={runBugs} projectId={projectId} onRefreshBugs={onRefreshBugs} />
             <div className="flex-1 min-h-0 overflow-y-auto px-2 py-2 space-y-1.5">
               {bugsFound.map((bug: RunStep & { name?: string }, i: number) => {
                 const displayName = runJsonBugDisplayName(bug);
@@ -1915,7 +1957,7 @@ function IssuesTab({
                       <div className="mt-1 flex items-center gap-1.5">
                         <BugCategoryTag category={category} />
                         {dbBug?.status && (
-                          <Badge variant={RUN_BUG_STATUS_BADGE[dbBug.status] ?? "neutral"} className="capitalize text-[10px]">
+                          <Badge variant={BUG_STATUS_BADGE[dbBug.status] ?? "neutral"} className="capitalize text-[10px]">
                             {dbBug.status.replace("_", " ")}
                           </Badge>
                         )}
@@ -2006,12 +2048,12 @@ function BugCard({
   const [bugStatus, setBugStatus] = React.useState<string | undefined>(dbBug?.status);
   const isOpen = !bugStatus || bugStatus === "open" || bugStatus === "in_progress";
 
-  async function resolveIssue() {
+  async function markForFix() {
     if (!projectId || !dbBug?.id || !isOpen) return;
     setBusy(true);
     try {
-      await patchProjectBug(projectId, dbBug.id, { status: "resolved" });
-      setBugStatus("resolved");
+      await patchProjectBug(projectId, dbBug.id, { status: "in_progress" });
+      setBugStatus("in_progress");
     } finally {
       setBusy(false);
     }
@@ -2060,10 +2102,10 @@ function BugCard({
           <BugCategoryTag category={category} />
           {bugStatus && (
             <Badge
-              variant={RUN_BUG_STATUS_BADGE[bugStatus] ?? "neutral"}
-              className="capitalize flex-shrink-0 text-[10px]"
+              variant={BUG_STATUS_BADGE[bugStatus] ?? "neutral"}
+              className="flex-shrink-0 text-[10px]"
             >
-              {bugStatus.replace("_", " ")}
+              {bugStatusLabel(bugStatus)}
             </Badge>
           )}
           <span className="text-[11px] font-mono text-muted-foreground/50 flex-shrink-0 tabular-nums">
@@ -2096,12 +2138,12 @@ function BugCard({
                   <div className="flex items-center gap-1.5 flex-shrink-0">
                     <Button
                       size="sm"
-                      variant="outline"
+                      variant="default"
                       className="h-7 px-3 text-[11px]"
                       disabled={busy}
-                      onClick={(e) => { e.stopPropagation(); resolveIssue(); }}
+                      onClick={(e) => { e.stopPropagation(); markForFix(); }}
                     >
-                      Mark as resolved
+                      Mark for fix
                     </Button>
                     <Button
                       size="sm"
@@ -2110,7 +2152,7 @@ function BugCard({
                       disabled={busy}
                       onClick={(e) => { e.stopPropagation(); ignoreIssue(); }}
                     >
-                      Ignore bug
+                      Ignore
                     </Button>
                   </div>
                 )}
@@ -2166,8 +2208,8 @@ function BugCard({
                   <div className="flex flex-wrap items-center gap-1.5">
                     <BugCategoryTag category={category} />
                     {dbBug?.status && (
-                      <Badge variant={RUN_BUG_STATUS_BADGE[dbBug.status] ?? "neutral"} className="capitalize text-[10px]">
-                        {dbBug.status.replace("_", " ")}
+                      <Badge variant={BUG_STATUS_BADGE[dbBug.status] ?? "neutral"} className="text-[10px]">
+                        {bugStatusLabel(dbBug.status)}
                       </Badge>
                     )}
                   </div>
@@ -2291,15 +2333,15 @@ function BugCard({
                 <>
                   <Button
                     size="sm"
-                    variant="outline"
+                    variant="default"
                     className="h-7 text-[11px]"
                     disabled={busy}
                     onClick={(e) => {
                       e.stopPropagation();
-                      resolveIssue();
+                      markForFix();
                     }}
                   >
-                    Mark as resolved
+                    Mark for fix
                   </Button>
                   <Button
                     size="sm"
@@ -2311,7 +2353,7 @@ function BugCard({
                       ignoreIssue();
                     }}
                   >
-                    Ignore bug
+                    Ignore
                   </Button>
                 </>
               )}

--- a/apps/web/src/pages/RunDetail.tsx
+++ b/apps/web/src/pages/RunDetail.tsx
@@ -1973,7 +1973,7 @@ function IssuesTab({
           </div>
           <div className="flex-1 min-w-0 min-h-0 overflow-y-auto">
             {selectedBug && (
-              <BugCard bug={selectedBug} runBugs={runBugs} runId={run.id} projectId={projectId} run={run} forceExpanded />
+              <BugCard bug={selectedBug} runBugs={runBugs} runId={run.id} projectId={projectId} run={run} forceExpanded onRefreshBugs={onRefreshBugs} />
             )}
           </div>
         </div>
@@ -2016,6 +2016,7 @@ function BugCard({
   projectId,
   run,
   forceExpanded = false,
+  onRefreshBugs,
 }: {
   bug: any;
   runBugs: {
@@ -2032,6 +2033,7 @@ function BugCard({
   projectId?: string;
   run: Run;
   forceExpanded?: boolean;
+  onRefreshBugs?: () => Promise<void> | void;
 }) {
   const [expanded, setExpanded] = React.useState(false);
   const [showRaw, setShowRaw] = React.useState(false);
@@ -2045,7 +2047,11 @@ function BugCard({
   const reportedIso = dbBug?.reported_at ?? run.completed_at ?? run.started_at ?? "";
   const isExpanded = forceExpanded || expanded;
 
+  // Sync local status with the latest dbBug.status whenever runBugs refreshes
   const [bugStatus, setBugStatus] = React.useState<string | undefined>(dbBug?.status);
+  React.useEffect(() => {
+    setBugStatus(dbBug?.status);
+  }, [dbBug?.status]);
   const isOpen = !bugStatus || bugStatus === "open" || bugStatus === "in_progress";
 
   async function markForFix() {
@@ -2054,6 +2060,7 @@ function BugCard({
     try {
       await patchProjectBug(projectId, dbBug.id, { status: "in_progress" });
       setBugStatus("in_progress");
+      await onRefreshBugs?.();
     } finally {
       setBusy(false);
     }
@@ -2072,6 +2079,7 @@ function BugCard({
         confidence: 100,
       });
       setBugStatus("wont_fix");
+      await onRefreshBugs?.();
     } finally {
       setBusy(false);
     }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keryai/mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Kery MCP server — lets AI agents in your IDE run browser tests via Kery",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/src/tools/bugs.ts
+++ b/packages/mcp/src/tools/bugs.ts
@@ -8,33 +8,61 @@ async function requireRunning(client: KeryClient) {
   return null;
 }
 
+// User-friendly triage names mapped to DB statuses.
+const STATUS_ALIASES: Record<string, "open" | "in_progress" | "resolved" | "wont_fix"> = {
+  needs_review: "open",
+  open: "open",
+  to_fix: "in_progress",
+  in_progress: "in_progress",
+  fixed: "resolved",
+  resolved: "resolved",
+  ignored: "wont_fix",
+  wont_fix: "wont_fix",
+};
+
+const FRIENDLY_STATUS: Record<string, string> = {
+  open: "needs_review",
+  in_progress: "to_fix",
+  resolved: "fixed",
+  wont_fix: "ignored",
+};
+
 export function registerBugsTool(server: McpServer, client: KeryClient) {
   server.tool(
     "kery_get_bugs",
-    `List bugs found by Kery AI testing for a project.
+    `List bugs found by Kery AI testing for a project, organized by triage state.
 
-WHEN TO USE:
-  • User asks "what bugs did kery find", "show me the issues", "are there any open bugs"
-  • After a test run completes to review what was discovered
-  • To get bug IDs for kery_update_bug (marking as resolved, wont_fix, etc.)
-  • Filtering bugs by route: use the returned destination_id to match against kery_list_routes IDs
-  • Filtering bugs by flow: use the returned test_id to match against kery_list_tests IDs
+TRIAGE WORKFLOW (this is the canonical flow):
+  1. After kery_run_test, the user opens the run URL and triages each bug:
+     - "Mark for fix" → the agent should fix it (status='to_fix' / DB 'in_progress')
+     - "Ignore"       → the agent should NOT fix it (status='ignored' / DB 'wont_fix')
+  2. The agent calls this tool with status='to_fix' to get the work queue.
+  3. After fixing each, the agent calls kery_update_bug with status='fixed'.
 
-Each bug includes name, description, severity (low/medium/high), category (visual/functional/ux/other),
-the URL where it was found, a status, and source attribution:
-  • destination_id — the route/page (from kery_list_routes) where the bug was found, or null
-  • test_id        — the saved test flow (from kery_list_tests) that triggered it, or null
-  Route-level bugs (no test_id) surface in the Route Detail Issues tab in the web UI.
+IMPORTANT — DO NOT START FIXING UNTIL THE USER HAS TRIAGED:
+  • When this tool returns bugs with status='needs_review' (the default state right after a run),
+    DO NOT fix them yet. Instead, share the run/bugs webUrl with the user and ask them to triage.
+  • Only fix bugs the user has explicitly marked as 'to_fix'.
 
-Screenshots are viewable in the web UI via the webUrl.
+STATUS VALUES (user-facing → DB):
+  • needs_review (open)       — just found, user hasn't decided
+  • to_fix      (in_progress) — user marked for fix → agent's work queue
+  • ignored     (wont_fix)    — user dismissed
+  • fixed       (resolved)    — agent confirmed fix
 
-After reviewing bugs, call kery_update_bug to mark them as resolved or wont_fix.`,
+Each bug returned includes destination_id (route) and test_id (flow) so you can filter by source.`,
     {
       projectId: z.string().uuid().describe("Project ID (get from kery_list_projects)"),
       status: z
-        .enum(["open", "resolved", "all"])
-        .default("open")
-        .describe("Filter by bug status. 'open' includes in_progress bugs. Default: 'open'."),
+        .enum([
+          "needs_review", "to_fix", "ignored", "fixed", "all",
+          // legacy aliases for backward compat:
+          "open", "in_progress", "resolved", "wont_fix",
+        ])
+        .default("all")
+        .describe(
+          "Filter by triage state. Use 'to_fix' to get the agent's work queue, 'needs_review' to see what still needs user triage. Default: 'all'.",
+        ),
       severity: z
         .enum(["high", "medium", "low", "all"])
         .default("all")
@@ -45,30 +73,48 @@ After reviewing bugs, call kery_update_bug to mark them as resolved or wont_fix.
       if (err) return { content: [{ type: "text", text: err }], isError: true };
 
       const allBugs = await client.getBugs(projectId);
-      let filtered = status === "all"
-        ? allBugs
-        : allBugs.filter((b) =>
-            status === "open"
-              ? b.status === "open" || b.status === "in_progress"
-              : b.status === "resolved",
-          );
 
-      if (severity !== "all") {
-        filtered = filtered.filter((b) => b.severity === severity);
-      }
+      const dbStatus = status === "all" ? null : STATUS_ALIASES[status];
+      let filtered = dbStatus == null ? allBugs : allBugs.filter((b) => b.status === dbStatus);
+      if (severity !== "all") filtered = filtered.filter((b) => b.severity === severity);
 
       const bugs = filtered.map(({ screenshotBase64, screenshotPath, ...rest }) => rest);
 
+      // Counts across the full project (independent of filter) — used to drive nudges.
+      const needsReviewCount = allBugs.filter((b) => b.status === "open").length;
+      const toFixCount = allBugs.filter((b) => b.status === "in_progress").length;
+
+      const webUrl = client.buildWebUrl(`/projects/${projectId}/bugs`);
       const nextSteps: string[] = [];
-      if (bugs.length > 0) {
+
+      if (needsReviewCount > 0 && (status === "all" || status === "needs_review" || status === "open")) {
         nextSteps.push(
-          `Found ${bugs.length} bugs. Use kery_update_bug with a bug's id to mark it as 'resolved' or 'wont_fix'.`,
+          `⚠ ${needsReviewCount} bug(s) still need user triage. Share this URL with the user and ask them to mark each as fix or ignore: ${webUrl}`,
         );
-        if (bugs.some((b) => b.severity === "high")) {
-          nextSteps.push("There are high-severity bugs — prioritize those first.");
+        nextSteps.push(
+          "Do NOT start fixing bugs until the user has triaged them. After the user marks bugs, call kery_get_bugs again with status='to_fix' to get the work queue.",
+        );
+      }
+
+      if (status === "to_fix" || status === "in_progress") {
+        if (bugs.length === 0) {
+          if (needsReviewCount > 0) {
+            nextSteps.push(`No bugs to fix yet. ${needsReviewCount} still awaiting user triage — share ${webUrl} with the user.`);
+          } else {
+            nextSteps.push("No bugs marked for fix. Ask the user if there are issues they want triaged, or run kery_run_test to find new bugs.");
+          }
+        } else {
+          nextSteps.push(
+            `${bugs.length} bug(s) marked for fix. Fix each and call kery_update_bug with status='fixed' (DB 'resolved') when done.`,
+          );
+          if (bugs.some((b) => b.severity === "high")) {
+            nextSteps.push("Prioritize high-severity bugs first.");
+          }
         }
-      } else {
-        nextSteps.push("No bugs found matching these filters. Run kery_run_test to discover bugs.");
+      }
+
+      if (status === "all" && bugs.length === 0) {
+        nextSteps.push("No bugs found. Run kery_run_test to discover bugs.");
       }
 
       return {
@@ -76,19 +122,25 @@ After reviewing bugs, call kery_update_bug to mark them as resolved or wont_fix.
           type: "text",
           text: JSON.stringify({
             totalCount: bugs.length,
+            counts: {
+              needs_review: needsReviewCount,
+              to_fix: toFixCount,
+              fixed: allBugs.filter((b) => b.status === "resolved").length,
+              ignored: allBugs.filter((b) => b.status === "wont_fix").length,
+            },
             bugs: bugs.map((b) => ({
               id: b.id,
               name: b.name,
               description: b.description,
               category: b.category,
               severity: b.severity,
-              status: b.status,
+              status: FRIENDLY_STATUS[b.status] ?? b.status,
               url: b.url,
               reportedAt: b.reportedAt,
               destination_id: (b as any).destination_id ?? null,
               test_id: (b as any).test_id ?? null,
             })),
-            webUrl: client.buildWebUrl(`/projects/${projectId}/bugs`),
+            webUrl,
             nextSteps,
           }),
         }],
@@ -98,38 +150,43 @@ After reviewing bugs, call kery_update_bug to mark them as resolved or wont_fix.
 
   server.tool(
     "kery_update_bug",
-    `Update the status of a bug — mark it as resolved, wont_fix, in_progress, or reopen it.
+    `Update a bug's triage state.
 
 WHEN TO USE:
-  • User says "mark that bug as resolved", "that's a false positive", "we fixed the login bug"
-  • Triaging bugs after a test run
-  • Tracking which bugs have been actioned
+  • Agent finished fixing a bug → status='fixed'
+  • User says "ignore that one" → status='ignored'
+  • Re-opening a previously triaged bug → status='needs_review'
 
-Bug statuses:
-  • 'open'        — newly found, not yet triaged
-  • 'in_progress' — being worked on
-  • 'resolved'    — fixed (run a new test to verify)
-  • 'wont_fix'    — acknowledged but won't be fixed (false positive, known limitation, etc.)
+STATUS VALUES (user-facing → DB):
+  • needs_review (open)       — back to untriaged
+  • to_fix      (in_progress) — user-style 'mark for fix' (rarely set by the agent)
+  • ignored     (wont_fix)    — dismissed
+  • fixed       (resolved)    — agent confirms fix
 
 Get bug IDs from kery_get_bugs.`,
     {
       projectId: z.string().uuid().describe("Project ID that owns the bug"),
       bugId: z.string().uuid().describe("Bug ID to update (get from kery_get_bugs)"),
       status: z
-        .enum(["open", "in_progress", "resolved", "wont_fix"])
-        .describe("New status for the bug"),
+        .enum([
+          "needs_review", "to_fix", "ignored", "fixed",
+          // legacy aliases:
+          "open", "in_progress", "resolved", "wont_fix",
+        ])
+        .describe("New triage state for the bug"),
     },
     async ({ projectId, bugId, status }) => {
       const err = await requireRunning(client);
       if (err) return { content: [{ type: "text", text: err }], isError: true };
 
-      await client.updateBug(projectId, bugId, status);
+      const dbStatus = STATUS_ALIASES[status];
+      await client.updateBug(projectId, bugId, dbStatus);
 
-      const statusMessages: Record<string, string> = {
-        resolved: "Bug marked as resolved. Run kery_run_test again to verify the fix.",
-        wont_fix: "Bug marked as wont_fix — it will be excluded from future open bug counts.",
-        in_progress: "Bug marked as in_progress — your team is working on it.",
-        open: "Bug reopened.",
+      const messages: Record<string, string> = {
+        resolved: "Bug marked as fixed. Consider re-running kery_run_test to verify the fix.",
+        wont_fix: "Bug marked as ignored — excluded from future open bug counts.",
+        in_progress: "Bug marked as to_fix — agent should fix this next.",
+        open: "Bug reopened — needs user triage again.",
       };
 
       return {
@@ -138,9 +195,9 @@ Get bug IDs from kery_get_bugs.`,
           text: JSON.stringify({
             updated: true,
             bugId,
-            newStatus: status,
-            message: statusMessages[status],
-            nextSteps: [statusMessages[status]],
+            newStatus: FRIENDLY_STATUS[dbStatus] ?? dbStatus,
+            message: messages[dbStatus],
+            nextSteps: [messages[dbStatus]],
           }),
         }],
       };

--- a/packages/mcp/src/tools/run.ts
+++ b/packages/mcp/src/tools/run.ts
@@ -31,7 +31,11 @@ TIMING & WAIT BEHAVIOR:
   • Set wait=true only when you need the full results inline (e.g. automated/CI flows). Then the tool blocks until the run finishes and returns bugs + summary.
   • Either way, results can be fetched later with kery_get_run using the runId.
 
-After the test, call kery_get_bugs to review bugs, or kery_get_run with the runId for full step-by-step details.`,
+POST-RUN TRIAGE — CRITICAL:
+  After the run finishes, the bugs are in 'needs_review' state. Do NOT start fixing them immediately.
+  Instead, share the run/bugs URL with the user and ask them to triage each bug (mark for fix / ignore).
+  Then call kery_get_bugs with status='to_fix' to get the work queue, fix each, and call
+  kery_update_bug status='fixed' when done.`,
     {
       projectId: z
         .string()
@@ -154,10 +158,12 @@ After the test, call kery_get_bugs to review bugs, or kery_get_run with the runI
                 runId,
                 status: "queued",
                 webUrl,
-                message: `Run started. Share this URL with the user so they can watch it live: ${webUrl}`,
+                message: `Run started. Share this URL with the user so they can watch live AND triage any bugs found: ${webUrl}`,
                 nextSteps: [
-                  `Share the webUrl with the user immediately — it is valid during and after the run.`,
-                  `Call kery_get_run with runId="${runId}" later to fetch results, or re-run kery_run_test with wait=true to block until completion.`,
+                  `Share the webUrl with the user — it stays valid during and after the run.`,
+                  `When the run completes, the user must triage each bug on that page (mark for fix or ignore) BEFORE you start fixing anything.`,
+                  `After the user triages, call kery_get_bugs with projectId="${projectId}" and status="to_fix" to get the work queue.`,
+                  `Fix each bug, then call kery_update_bug with status="fixed" to confirm.`,
                 ],
               }),
             }],


### PR DESCRIPTION
## Summary

After a run, bugs default to 'Needs review' state. The user explicitly marks each as **Mark for fix** or **Ignore**. The MCP nudges the agent to wait for triage before fixing, then exposes the 'to_fix' queue for the agent to work through.

## State machine (no migration)

| User-facing | DB | Meaning |
|---|---|---|
| Needs review | \`open\` | Default after run; user hasn't decided |
| To fix       | \`in_progress\` | User marked → agent queue |
| Ignored      | \`wont_fix\` | User dismissed |
| Fixed        | \`resolved\` | Agent confirmed fix |

## UI changes

- Bug action buttons: \`Mark as resolved\` → **Mark for fix** (default variant), \`Ignore bug\` → **Ignore**
- Centralized status labels via \`bugStatusLabel()\` — used in RunDetail, Bugs, FlowDetail, PageDetail, and PDF export
- **Triage banner** above the issue list (both \`/bugs\` and Run → Issues tab) when any bugs are still \`open\`: *"N bugs need review · Mark all for fix"*. Subtle band, primary tint.

## MCP changes (\`@keryai/mcp\` 0.2.0)

- \`kery_get_bugs\` accepts triage-friendly status values: \`needs_review\`, \`to_fix\`, \`ignored\`, \`fixed\`. Legacy raw values still work. Response includes a per-state \`counts\` object.
- When bugs are still in \`needs_review\`, the response prefixes a strong nudge telling the agent NOT to start fixing until the user triages.
- \`kery_update_bug\` accepts both new and legacy status values; agent uses \`status='fixed'\` to confirm a fix.
- \`kery_run_test\` non-blocking response walks the agent through the full triage handoff in \`nextSteps\`.

## Test plan
- [ ] Run a test that produces bugs
- [ ] Open \`/bugs\`: banner shows count, buttons say "Mark for fix" / "Ignore"
- [ ] Click "Mark for fix" → status pill flips to "To fix" (yellow)
- [ ] Click "Ignore" on another → status pill flips to "Ignored" (neutral)
- [ ] Click "Mark all for fix" → all remaining 'open' flip to 'in_progress'; banner disappears
- [ ] Open Run → Issues tab: same UI + banner
- [ ] Agent flow via MCP:
  - [ ] kery_run_test returns nextSteps mentioning triage
  - [ ] kery_get_bugs with no filter shows nudge when needs_review > 0
  - [ ] After marking some for fix, kery_get_bugs status='to_fix' returns those bugs
  - [ ] kery_update_bug status='fixed' updates DB to 'resolved'

🤖 Generated with [Claude Code](https://claude.com/claude-code)