### PR TITLE
Add custom OpenAI-compatible endpoint support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
 
+# Or bring your own OpenAI-compatible endpoint (Azure, DashScope, Ollama, LiteLLM, …).
+# Point models at it with the custom/ prefix, e.g. AGENT_MODEL=custom/qwen3-coder-plus
+# The key is optional — local endpoints often need none.
+# CUSTOM_LLM_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# CUSTOM_LLM_API_KEY=
+
 # ─── Model configuration (defaults shown) ────────────────────────────────────
 # Agent: vision + reasoning for browser automation steps
 AGENT_MODEL=openai/gpt-4.1-mini

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Once connected, your AI assistant can scan your app, run tests, and triage bugs 
 | `OPENAI_API_KEY` | — | Direct OpenAI key |
 | `ANTHROPIC_API_KEY` | — | Direct Anthropic key |
 | `GEMINI_API_KEY` | — | Direct Google Gemini key |
+| `CUSTOM_LLM_BASE_URL` | — | Any OpenAI-compatible endpoint (Azure, DashScope, Ollama, LiteLLM…). Use model ids prefixed `custom/`, e.g. `AGENT_MODEL=custom/qwen3-coder-plus` |
+| `CUSTOM_LLM_API_KEY` | — | API key for the custom endpoint (optional — local endpoints often need none) |
 | `AGENT_MODEL` | `anthropic/claude-sonnet-5` | Model for browser navigation decisions |
 | `AUXILIARY_MODEL` | `anthropic/claude-haiku-4.5` | Crawl, path planning, memory curation, summarization |
 | `REVIEW_AGENT_MODEL` | `anthropic/claude-sonnet-5` | Post-run holistic and filmstrip screenshot analysis |

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -14,6 +14,8 @@ export const config = {
   openrouterApiKey: process.env.OPENROUTER_API_KEY || "",
   anthropicApiKey: process.env.ANTHROPIC_API_KEY || "",
   geminiApiKey: process.env.GEMINI_API_KEY || "",
+  customLlmBaseUrl: process.env.CUSTOM_LLM_BASE_URL || "",
+  customLlmApiKey: process.env.CUSTOM_LLM_API_KEY || "",
   agentModel: process.env.AGENT_MODEL || "anthropic/claude-sonnet-5",
   /** Crawl, path plans, memory curation, intents, summarization — text/JSON auxiliary stack. `CRAWL_MODEL` is a deprecated alias. */
   auxiliaryModel:

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -13,7 +13,7 @@ import { config as envConfig } from "../config.js";
 
 // ─── API Key provider constants ────────────────────────────────────────────────
 
-const API_KEY_PROVIDERS = ["openai", "anthropic", "gemini", "openrouter"] as const;
+const API_KEY_PROVIDERS = ["openai", "anthropic", "gemini", "openrouter", "custom"] as const;
 type ApiKeyProvider = (typeof API_KEY_PROVIDERS)[number];
 
 const PROVIDER_DB_KEY: Record<ApiKeyProvider, string> = {
@@ -21,31 +21,40 @@ const PROVIDER_DB_KEY: Record<ApiKeyProvider, string> = {
   anthropic: "apiKey.anthropic",
   gemini: "apiKey.gemini",
   openrouter: "apiKey.openrouter",
+  custom: "apiKey.custom",
 };
+
+/** The custom endpoint's base URL — not a secret, stored in plain text (keys are encrypted). */
+const CUSTOM_BASE_URL_DB_KEY = "llm.customBaseUrl";
 
 const PROVIDER_ENV_KEY: Record<ApiKeyProvider, string> = {
   openai: envConfig.openaiApiKey,
   anthropic: envConfig.anthropicApiKey,
   gemini: envConfig.geminiApiKey,
   openrouter: envConfig.openrouterApiKey,
+  custom: envConfig.customLlmApiKey,
 };
 
-const PROVIDER_CONFIG_KEY: Record<ApiKeyProvider, "openaiApiKey" | "anthropicApiKey" | "geminiApiKey" | "openrouterApiKey"> = {
+type ProviderConfigKey = "openaiApiKey" | "anthropicApiKey" | "geminiApiKey" | "openrouterApiKey" | "customLlmApiKey";
+
+const PROVIDER_CONFIG_KEY: Record<ApiKeyProvider, ProviderConfigKey> = {
   openai: "openaiApiKey",
   anthropic: "anthropicApiKey",
   gemini: "geminiApiKey",
   openrouter: "openrouterApiKey",
+  custom: "customLlmApiKey",
 };
 
 /** Read DB API key overrides and merge into the running engine config (DB wins over .env). */
 export async function applyDbApiKeySettings(storage: StorageAdapter): Promise<void> {
   try {
     const all = await storage.getSettings();
-    const overrides: Partial<Record<"openaiApiKey" | "anthropicApiKey" | "geminiApiKey" | "openrouterApiKey", string>> = {};
+    const overrides: Partial<Record<ProviderConfigKey | "customLlmBaseUrl", string>> = {};
     for (const provider of API_KEY_PROVIDERS) {
       const raw = all[PROVIDER_DB_KEY[provider]];
       if (raw) overrides[PROVIDER_CONFIG_KEY[provider]] = decryptValue(raw);
     }
+    if (all[CUSTOM_BASE_URL_DB_KEY]) overrides.customLlmBaseUrl = all[CUSTOM_BASE_URL_DB_KEY];
     if (Object.keys(overrides).length > 0) updateEngineConfig(overrides);
   } catch {
     // settings table may not exist yet — skip silently
@@ -332,7 +341,10 @@ export function registerSettingsRoutes(app: FastifyInstance, storage: StorageAda
       dbKeys = await storage.getSettings();
     } catch {}
 
-    const result: Record<ApiKeyProvider, { hasKey: boolean; source: "env" | "db" | "none"; maskedKey?: string }> = {} as any;
+    const result: Record<
+      ApiKeyProvider,
+      { hasKey: boolean; source: "env" | "db" | "none"; maskedKey?: string; baseUrl?: string; baseUrlSource?: "env" | "db" | "none" }
+    > = {} as any;
     for (const provider of API_KEY_PROVIDERS) {
       const dbRaw = dbKeys[PROVIDER_DB_KEY[provider]];
       if (dbRaw) {
@@ -345,6 +357,11 @@ export function registerSettingsRoutes(app: FastifyInstance, storage: StorageAda
       }
     }
 
+    // The custom provider is defined by its base URL (the key is optional — local endpoints).
+    const dbBaseUrl = dbKeys[CUSTOM_BASE_URL_DB_KEY];
+    result.custom.baseUrl = dbBaseUrl || envConfig.customLlmBaseUrl || undefined;
+    result.custom.baseUrlSource = dbBaseUrl ? "db" : envConfig.customLlmBaseUrl ? "env" : "none";
+
     reply.send(result);
   });
 
@@ -353,6 +370,9 @@ export function registerSettingsRoutes(app: FastifyInstance, storage: StorageAda
     anthropic: z.string().optional(),
     gemini: z.string().optional(),
     openrouter: z.string().optional(),
+    custom: z.string().optional(),
+    /** Base URL of the custom OpenAI-compatible endpoint. Empty string clears the DB override. */
+    customBaseUrl: z.string().optional(),
   });
 
   /**
@@ -373,8 +393,24 @@ export function registerSettingsRoutes(app: FastifyInstance, storage: StorageAda
       const dbKey = PROVIDER_DB_KEY[provider];
       if (value.trim() === "") {
         await storage.deleteSettings([dbKey]);
+        updateEngineConfig({ [PROVIDER_CONFIG_KEY[provider]]: PROVIDER_ENV_KEY[provider] });
       } else {
         await storage.saveSetting(dbKey, encryptValue(value.trim()));
+      }
+    }
+
+    const customBaseUrl = parsed.data.customBaseUrl;
+    if (customBaseUrl !== undefined) {
+      const trimmed = customBaseUrl.trim();
+      if (trimmed === "") {
+        await storage.deleteSettings([CUSTOM_BASE_URL_DB_KEY]);
+        updateEngineConfig({ customLlmBaseUrl: envConfig.customLlmBaseUrl });
+      } else {
+        if (!/^https?:\/\//i.test(trimmed)) {
+          reply.code(400).send({ error: "invalid_base_url", message: "Base URL must start with http:// or https://" });
+          return;
+        }
+        await storage.saveSetting(CUSTOM_BASE_URL_DB_KEY, trimmed);
       }
     }
 
@@ -394,11 +430,14 @@ export function registerSettingsRoutes(app: FastifyInstance, storage: StorageAda
       reply.code(400).send({ error: "unknown provider" });
       return;
     }
-    await storage.deleteSettings([PROVIDER_DB_KEY[provider as ApiKeyProvider]]);
+    const dbKeys = [PROVIDER_DB_KEY[provider as ApiKeyProvider]];
+    if (provider === "custom") dbKeys.push(CUSTOM_BASE_URL_DB_KEY);
+    await storage.deleteSettings(dbKeys);
 
     // Revert in-memory config to env value for this provider
     const envValue = PROVIDER_ENV_KEY[provider as ApiKeyProvider];
     updateEngineConfig({ [PROVIDER_CONFIG_KEY[provider as ApiKeyProvider]]: envValue });
+    if (provider === "custom") updateEngineConfig({ customLlmBaseUrl: envConfig.customLlmBaseUrl });
 
     reply.send({ ok: true });
   });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -24,6 +24,8 @@ initEngineConfig({
   openrouterApiKey: config.openrouterApiKey,
   anthropicApiKey: config.anthropicApiKey,
   geminiApiKey: config.geminiApiKey,
+  customLlmBaseUrl: config.customLlmBaseUrl,
+  customLlmApiKey: config.customLlmApiKey,
   agentModel: config.agentModel,
   auxiliaryModel: config.auxiliaryModel,
   reviewAgentModel: config.reviewAgentModel,

--- a/apps/web/src/lib/llmModelAvailability.ts
+++ b/apps/web/src/lib/llmModelAvailability.ts
@@ -1,21 +1,27 @@
 /**
  * Mirrors packages/engine/src/llmProviders.ts — keep rules in sync when changing providers.
  */
-export type CustomProviderId = "openai" | "anthropic" | "gemini" | "openrouter";
+export type CustomProviderId = "openai" | "anthropic" | "gemini" | "openrouter" | "custom";
 
 export type LlmKeyPresence = {
   hasOpenRouter: boolean;
   hasOpenAI: boolean;
   hasAnthropic: boolean;
   hasGemini: boolean;
+  /** Custom OpenAI-compatible endpoint configured (base URL present). */
+  hasCustom: boolean;
 };
 
 const OPENROUTER_ONLY_PREFIXES = ["deepseek/", "meta/", "mistral/", "cohere/", "perplexity/", "qwen/"];
 
+/** Model ids with this prefix always route to the custom OpenAI-compatible endpoint. */
+export const CUSTOM_MODEL_PREFIX = "custom/";
+
 function inferDirectProvider(
   model: string
-): "openai" | "anthropic" | "gemini" | "openrouter_only" {
+): "openai" | "anthropic" | "gemini" | "custom" | "openrouter_only" {
   const m = model.trim();
+  if (m.startsWith(CUSTOM_MODEL_PREFIX)) return "custom";
   if (m.startsWith("openai/") || m.startsWith("gpt-")) return "openai";
   if (m.startsWith("anthropic/") || m.startsWith("claude")) return "anthropic";
   if (m.startsWith("google/") || m.startsWith("gemini-")) return "gemini";
@@ -27,8 +33,9 @@ function inferDirectProvider(
 
 /** Whether the user can select this model id given which API keys exist (mirrors engine `isModelRunnableWithConfig`). */
 export function isModelSelectable(modelId: string, keys: LlmKeyPresence): boolean {
-  if (keys.hasOpenRouter) return true;
   const p = inferDirectProvider(modelId);
+  if (p === "custom") return keys.hasCustom;
+  if (keys.hasOpenRouter || keys.hasCustom) return true;
   if (p === "openrouter_only") return false;
   if (p === "openai") return keys.hasOpenAI;
   if (p === "anthropic") return keys.hasAnthropic;
@@ -36,8 +43,9 @@ export function isModelSelectable(modelId: string, keys: LlmKeyPresence): boolea
 }
 
 export function modelMissingKeyLabel(modelId: string, keys: LlmKeyPresence): string | null {
-  if (keys.hasOpenRouter) return null;
   const p = inferDirectProvider(modelId);
+  if (p === "custom") return keys.hasCustom ? null : "Requires a custom endpoint (Settings → API Keys)";
+  if (keys.hasOpenRouter || keys.hasCustom) return null;
   if (p === "openrouter_only") return "Requires OpenRouter";
   if (p === "openai" && !keys.hasOpenAI) return "Missing OPENAI_API_KEY or OPENROUTER_API_KEY";
   if (p === "anthropic" && !keys.hasAnthropic) return "Missing ANTHROPIC_API_KEY or OPENROUTER_API_KEY";
@@ -59,6 +67,9 @@ export function composeCustomModel(provider: CustomProviderId, raw: string): str
     case "gemini":
       if (t.startsWith("google/") || t.startsWith("gemini-")) return t;
       return `google/${t}`;
+    case "custom":
+      if (t.startsWith(CUSTOM_MODEL_PREFIX)) return t;
+      return `${CUSTOM_MODEL_PREFIX}${t}`;
     case "openrouter":
       return t;
   }
@@ -68,6 +79,7 @@ export function composeCustomModel(provider: CustomProviderId, raw: string): str
 export function parseStoredModelForCustomUi(model: string): { provider: CustomProviderId; raw: string } {
   const m = model.trim();
   if (!m) return { provider: "openrouter", raw: "" };
+  if (m.startsWith(CUSTOM_MODEL_PREFIX)) return { provider: "custom", raw: m.slice(CUSTOM_MODEL_PREFIX.length) };
   if (m.startsWith("openai/")) return { provider: "openai", raw: m.slice("openai/".length) };
   if (m.startsWith("gpt-")) return { provider: "openai", raw: m };
   if (m.startsWith("anthropic/")) return { provider: "anthropic", raw: m.slice("anthropic/".length) };

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -169,6 +169,22 @@ export const Settings: React.FC = () => {
                   </div>
                 );
               })}
+              <div
+                className="glass-card-flat card-stagger"
+                style={{ animationDelay: `${API_KEY_CONFIG.length * 50}ms` }}
+              >
+                <CustomEndpointCard
+                  info={apiKeySettings?.custom ?? null}
+                  onSave={async (baseUrl, key) => {
+                    await saveApiKeys({ customBaseUrl: baseUrl, ...(key !== null ? { custom: key } : {}) });
+                    await refreshAll();
+                  }}
+                  onRemove={async () => {
+                    await deleteApiKey("custom");
+                    await refreshAll();
+                  }}
+                />
+              </div>
             </div>
           </div>
 
@@ -630,6 +646,250 @@ function ApiKeyCard({
   );
 }
 
+/**
+ * Card for the custom OpenAI-compatible endpoint (Azure, DashScope, Ollama, LiteLLM, …).
+ * Unlike the provider cards it has two fields: a base URL (required, not secret) and an
+ * API key (optional — local endpoints often don't need one).
+ */
+function CustomEndpointCard({
+  info,
+  onSave,
+  onRemove,
+}: {
+  info: ApiKeyInfo | null;
+  /** key === null means "leave the stored key unchanged". */
+  onSave: (baseUrl: string, key: string | null) => Promise<void>;
+  onRemove: () => Promise<void>;
+}) {
+  const [editing, setEditing] = React.useState(false);
+  const [urlValue, setUrlValue] = React.useState("");
+  const [keyValue, setKeyValue] = React.useState("");
+  const [showKey, setShowKey] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+
+  React.useEffect(() => {
+    if (editing) {
+      setUrlValue(info?.baseUrl ?? "");
+    } else {
+      setUrlValue(""); setKeyValue(""); setShowKey(false); setError("");
+    }
+  }, [editing, info?.baseUrl]);
+
+  async function handleSave() {
+    const url = urlValue.trim();
+    if (!url) { setError("Enter the endpoint base URL."); return; }
+    if (!/^https?:\/\//i.test(url)) { setError("Base URL must start with http:// or https://."); return; }
+    setSaving(true);
+    setError("");
+    try {
+      await onSave(url, keyValue.trim() ? keyValue.trim() : null);
+      setEditing(false);
+    } catch {
+      setError("Failed to save. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirmDelete) { setConfirmDelete(true); return; }
+    setSaving(true);
+    try {
+      await onRemove();
+      setConfirmDelete(false);
+    } catch {
+      setError("Failed to remove endpoint.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isLoading = info === null;
+  const urlSource = info?.baseUrlSource ?? "none";
+  const configured = urlSource !== "none";
+  const hasDbUrl = urlSource === "db";
+  const keyHint =
+    info?.source === "db" && info.maskedKey
+      ? `Key ${info.maskedKey}`
+      : info?.source === "env"
+        ? "Key from .env"
+        : "No key (optional)";
+
+  return (
+    <div className="p-4 space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <div className={cn(
+            "h-8 w-8 rounded-xl flex items-center justify-center shrink-0",
+            configured ? "bg-primary/10 text-primary" : "bg-foreground/6 text-muted-foreground",
+          )}>
+            <Code className="h-4 w-4" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[13px] font-semibold text-foreground truncate">Custom endpoint</p>
+            <p className="text-[11px] text-muted-foreground truncate">Any OpenAI-compatible API — Azure, DashScope, Ollama, LiteLLM…</p>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="h-5 w-16 rounded bg-foreground/6 animate-pulse shrink-0" />
+        ) : (
+          <div className="shrink-0">
+            {hasDbUrl && <Badge variant="success" className="text-[10px] px-1.5 h-4 font-medium">DB override</Badge>}
+            {urlSource === "env" && <Badge variant="neutral" className="text-[10px] px-1.5 h-4 font-medium">From .env</Badge>}
+            {!configured && <Badge variant="warning" className="text-[10px] px-1.5 h-4 font-medium">Not configured</Badge>}
+          </div>
+        )}
+      </div>
+
+      {!editing && (
+        <div className="space-y-2">
+          {isLoading ? (
+            <div className="h-8 w-full rounded-lg bg-foreground/4 animate-pulse" />
+          ) : (
+            <div className="rounded-lg border border-border/60 bg-background/40 px-3 py-2 flex items-center justify-between gap-2 min-h-[34px]">
+              <div className="min-w-0">
+                {configured ? (
+                  <>
+                    <p className="font-mono text-[11px] text-foreground/70 truncate">{info?.baseUrl}</p>
+                    <p className="text-[10px] text-muted-foreground/60 truncate">{keyHint}</p>
+                  </>
+                ) : (
+                  <p className="text-[11px] text-muted-foreground/60 truncate italic">
+                    No endpoint configured — use models like <span className="font-mono not-italic">custom/&lt;model-id&gt;</span> once set
+                  </p>
+                )}
+              </div>
+              <div className="flex items-center gap-1 shrink-0">
+                {hasDbUrl && (
+                  <button
+                    type="button"
+                    onClick={() => { setConfirmDelete(false); handleDelete(); }}
+                    disabled={saving}
+                    title="Remove DB override"
+                    className="text-muted-foreground/50 hover:text-destructive transition-colors disabled:opacity-40 p-0.5"
+                  >
+                    <Trash className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              disabled={isLoading || saving}
+              className="text-[11px] text-muted-foreground/70 hover:text-foreground transition-colors py-1 px-1.5 rounded-md hover:bg-foreground/4 flex items-center gap-1 disabled:opacity-40"
+            >
+              <PencilSimple className="h-3 w-3" />
+              {configured ? "Update endpoint" : "Add endpoint"}
+            </button>
+          </div>
+
+          {confirmDelete && (
+            <div className="flex items-center gap-2 text-[11px] text-destructive animate-fade-in">
+              <Warning className="h-3.5 w-3.5 shrink-0" />
+              <span>Remove endpoint and key? (falls back to .env)</span>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={saving}
+                className="underline underline-offset-2 hover:opacity-80 disabled:opacity-40"
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(false)}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {editing && (
+        <div className="space-y-2.5 rounded-lg border border-border/70 bg-background/30 p-3 animate-fade-in">
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-[11px] font-medium text-foreground">
+              {configured ? "Update custom endpoint" : "Add custom endpoint"}
+            </p>
+            <button
+              type="button"
+              onClick={() => setEditing(false)}
+              className="text-[10px] text-muted-foreground/60 hover:text-foreground transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+
+          <div>
+            <label className="text-[10px] text-muted-foreground block mb-0.5">Base URL</label>
+            <Input
+              value={urlValue}
+              onChange={(e) => { setUrlValue(e.target.value); setError(""); }}
+              placeholder="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+              className="mono-ui text-[11px]"
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+              onKeyDown={(e) => { if (e.key === "Enter") handleSave(); }}
+            />
+          </div>
+
+          <div>
+            <label className="text-[10px] text-muted-foreground block mb-0.5">
+              API key <span className="text-muted-foreground/60">(optional — leave blank to keep the stored key)</span>
+            </label>
+            <div className="relative">
+              <Input
+                type={showKey ? "text" : "password"}
+                value={keyValue}
+                onChange={(e) => { setKeyValue(e.target.value); setError(""); }}
+                placeholder="sk-…"
+                className="mono-ui text-[11px] pr-9"
+                spellCheck={false}
+                autoCapitalize="off"
+                autoCorrect="off"
+                onKeyDown={(e) => { if (e.key === "Enter") handleSave(); }}
+              />
+              <button
+                type="button"
+                onClick={() => setShowKey((s) => !s)}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-foreground transition-colors"
+                tabIndex={-1}
+              >
+                {showKey ? <EyeSlash className="h-3.5 w-3.5" /> : <EyeIcon className="h-3.5 w-3.5" />}
+              </button>
+            </div>
+          </div>
+
+          <p className="text-[10px] text-muted-foreground/70 leading-relaxed">
+            Then pick models with the <span className="font-mono">custom/</span> prefix (e.g. <span className="font-mono">custom/qwen3-coder-plus</span>) via "Use custom model" below.
+          </p>
+
+          {error && <p className="text-[11px] text-destructive">{error}</p>}
+
+          <div className="flex gap-2 pt-0.5">
+            <Button type="button" size="sm" onClick={handleSave} disabled={saving} loading={saving}>
+              Save endpoint
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={() => setEditing(false)} disabled={saving}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Model configuration ────────────────────────────────────────────────────
 
 type ModelOption = { value: string; label: string; price?: string };
@@ -695,6 +955,7 @@ const CUSTOM_PROVIDER_OPTIONS: { value: CustomProviderId; label: string }[] = [
   { value: "anthropic", label: "Anthropic" },
   { value: "gemini", label: "Google Gemini" },
   { value: "openrouter", label: "OpenRouter (any id)" },
+  { value: "custom", label: "Custom endpoint" },
 ];
 
 const MODEL_CONFIG: {
@@ -740,6 +1001,7 @@ function customModelPlaceholder(provider: CustomProviderId): string {
     case "anthropic":  return "e.g. claude-sonnet-5";
     case "gemini":     return "e.g. gemini-3.5-flash-lite";
     case "openrouter": return "e.g. mistralai/mistral-small-3.1-24b-instruct";
+    case "custom":     return "e.g. qwen3-coder-plus";
   }
 }
 
@@ -974,6 +1236,9 @@ function ModelSlotCard({
 
           {customProvider === "openrouter" && (
             <p className="text-[10px] text-muted-foreground/60">Use full slug: vendor/model</p>
+          )}
+          {customProvider === "custom" && (
+            <p className="text-[10px] text-muted-foreground/60">Sent to your custom endpoint (Settings → API Keys) exactly as typed</p>
           )}
 
           <div className="grid grid-cols-2 gap-2">

--- a/apps/web/src/projectApi.ts
+++ b/apps/web/src/projectApi.ts
@@ -383,6 +383,8 @@ export type LlmKeyPresence = {
   hasOpenAI: boolean;
   hasAnthropic: boolean;
   hasGemini: boolean;
+  /** Custom OpenAI-compatible endpoint configured (base URL present). */
+  hasCustom: boolean;
 };
 
 /** USD per 1M tokens — used for run cost estimates when using a custom model id. */
@@ -440,7 +442,7 @@ export async function savePlatformSettings(settings: { maxConcurrency: number })
 
 // --- API Key settings ---
 
-export type ApiKeyProvider = "openai" | "anthropic" | "gemini" | "openrouter";
+export type ApiKeyProvider = "openai" | "anthropic" | "gemini" | "openrouter" | "custom";
 
 export type ApiKeyInfo = {
   hasKey: boolean;
@@ -448,6 +450,10 @@ export type ApiKeyInfo = {
   source: "env" | "db" | "none";
   /** Masked hint for DB-stored keys, e.g. "••••••••••••abcd". Not present for env keys. */
   maskedKey?: string;
+  /** Custom provider only: effective base URL of the OpenAI-compatible endpoint. */
+  baseUrl?: string;
+  /** Custom provider only: where the base URL comes from. */
+  baseUrlSource?: "env" | "db" | "none";
 };
 
 export type ApiKeySettingsResponse = Record<ApiKeyProvider, ApiKeyInfo>;
@@ -456,7 +462,7 @@ export async function fetchApiKeySettings(): Promise<ApiKeySettingsResponse> {
   return apiFetch(`${API_BASE}/api/settings/api-keys`);
 }
 
-export async function saveApiKeys(keys: Partial<Record<ApiKeyProvider, string>>) {
+export async function saveApiKeys(keys: Partial<Record<ApiKeyProvider, string>> & { customBaseUrl?: string }) {
   return apiFetch(`${API_BASE}/api/settings/api-keys`, {
     method: "PUT",
     body: JSON.stringify(keys),

--- a/apps/worker/src/config.ts
+++ b/apps/worker/src/config.ts
@@ -12,6 +12,8 @@ export const config = {
   openrouterApiKey: process.env.OPENROUTER_API_KEY || "",
   anthropicApiKey: process.env.ANTHROPIC_API_KEY || "",
   geminiApiKey: process.env.GEMINI_API_KEY || "",
+  customLlmBaseUrl: process.env.CUSTOM_LLM_BASE_URL || "",
+  customLlmApiKey: process.env.CUSTOM_LLM_API_KEY || "",
   agentModel: process.env.AGENT_MODEL || "anthropic/claude-sonnet-5",
   auxiliaryModel:
     process.env.AUXILIARY_MODEL ||

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -9,6 +9,8 @@ initEngineConfig({
   openrouterApiKey: config.openrouterApiKey,
   anthropicApiKey: config.anthropicApiKey,
   geminiApiKey: config.geminiApiKey,
+  customLlmBaseUrl: config.customLlmBaseUrl,
+  customLlmApiKey: config.customLlmApiKey,
   agentModel: config.agentModel,
   auxiliaryModel: config.auxiliaryModel,
   reviewAgentModel: config.reviewAgentModel,
@@ -32,10 +34,13 @@ try {
     "apiKey.anthropic": "anthropicApiKey",
     "apiKey.gemini": "geminiApiKey",
     "apiKey.openrouter": "openrouterApiKey",
+    "apiKey.custom": "customLlmApiKey",
   };
   for (const [dbKey, cfgKey] of Object.entries(keyMap)) {
     if (all[dbKey]) keyOverrides[cfgKey] = decryptValue(all[dbKey]);
   }
+  // Base URL is not a secret — stored in plain text, unlike the encrypted keys above.
+  if (all["llm.customBaseUrl"]) keyOverrides.customLlmBaseUrl = all["llm.customBaseUrl"];
   const modelOverrides: Record<string, string> = {};
   const modelMap: Record<string, string> = {
     "model.agentModel": "agentModel",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      CUSTOM_LLM_BASE_URL: ${CUSTOM_LLM_BASE_URL:-}
+      CUSTOM_LLM_API_KEY: ${CUSTOM_LLM_API_KEY:-}
       AGENT_MODEL: ${AGENT_MODEL:-anthropic/claude-sonnet-5}
       REVIEW_AGENT_MODEL: ${REVIEW_AGENT_MODEL:-anthropic/claude-sonnet-5}
       AUXILIARY_MODEL: ${AUXILIARY_MODEL:-${CRAWL_MODEL:-anthropic/claude-haiku-4.5}}
@@ -77,6 +79,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      CUSTOM_LLM_BASE_URL: ${CUSTOM_LLM_BASE_URL:-}
+      CUSTOM_LLM_API_KEY: ${CUSTOM_LLM_API_KEY:-}
       AGENT_MODEL: ${AGENT_MODEL:-anthropic/claude-sonnet-5}
       REVIEW_AGENT_MODEL: ${REVIEW_AGENT_MODEL:-anthropic/claude-sonnet-5}
       AUXILIARY_MODEL: ${AUXILIARY_MODEL:-${CRAWL_MODEL:-anthropic/claude-haiku-4.5}}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -391,7 +391,7 @@ export class KeryClient {
   }
 
   async updateApiKeys(
-    keys: Partial<Record<"openai" | "anthropic" | "gemini" | "openrouter", string>>,
+    keys: Partial<Record<"openai" | "anthropic" | "gemini" | "openrouter" | "custom" | "customBaseUrl", string>>,
   ): Promise<void> {
     await this.fetch("/api/settings/api-keys", { method: "PUT", body: JSON.stringify(keys) });
   }

--- a/packages/engine/src/__tests__/llmProviders.test.ts
+++ b/packages/engine/src/__tests__/llmProviders.test.ts
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  inferModelProviderRequirement,
+  isModelRunnableWithConfig,
+  modelUnavailableReason,
+  getLlmKeyPresence,
+  hasCustomEndpoint,
+  wireModelForCustomEndpoint,
+  CUSTOM_MODEL_PREFIX,
+} from "../llmProviders.js";
+import type { EngineConfig } from "../config.js";
+
+const baseConfig = (overrides: Partial<EngineConfig> = {}): EngineConfig => ({
+  openaiApiKey: "",
+  openrouterApiKey: "",
+  anthropicApiKey: "",
+  geminiApiKey: "",
+  agentModel: "anthropic/claude-sonnet-5",
+  auxiliaryModel: "anthropic/claude-haiku-4.5",
+  reviewAgentModel: "anthropic/claude-sonnet-5",
+  stagehandEnabled: false,
+  stagehandModel: "anthropic/claude-haiku-4.5",
+  runTimeoutMinutes: 15,
+  llmTimeoutMs: 45000,
+  reviewTimeoutMs: 30000,
+  ...overrides,
+});
+
+test("custom/ prefix classifies as the custom provider", () => {
+  assert.deepEqual(inferModelProviderRequirement("custom/qwen3-coder-plus"), { kind: "custom" });
+  assert.deepEqual(inferModelProviderRequirement(`${CUSTOM_MODEL_PREFIX}gpt-4o`), { kind: "custom" });
+});
+
+test("custom/ models run only when a custom endpoint is configured", () => {
+  const withEndpoint = baseConfig({ customLlmBaseUrl: "https://example.com/v1" });
+  const withoutEndpoint = baseConfig({ openrouterApiKey: "sk-or-xxx" });
+  assert.equal(isModelRunnableWithConfig("custom/qwen3-coder-plus", withEndpoint), true);
+  // OpenRouter cannot serve an explicitly custom-routed model.
+  assert.equal(isModelRunnableWithConfig("custom/qwen3-coder-plus", withoutEndpoint), false);
+  assert.match(modelUnavailableReason("custom/qwen3-coder-plus", withoutEndpoint) ?? "", /CUSTOM_LLM_BASE_URL/);
+});
+
+test("a custom endpoint acts as catch-all fallback for otherwise unrunnable models", () => {
+  const cfg = baseConfig({ customLlmBaseUrl: "https://example.com/v1" });
+  assert.equal(isModelRunnableWithConfig("qwen3-max", cfg), true);
+  assert.equal(isModelRunnableWithConfig("openai/gpt-4o", cfg), true);
+  assert.equal(isModelRunnableWithConfig("anthropic/claude-sonnet-5", cfg), true);
+});
+
+test("no keys and no endpoint means nothing is runnable", () => {
+  const cfg = baseConfig();
+  assert.equal(isModelRunnableWithConfig("qwen3-max", cfg), false);
+  assert.equal(isModelRunnableWithConfig("openai/gpt-4o", cfg), false);
+});
+
+test("endpoint presence does not require an API key", () => {
+  assert.equal(hasCustomEndpoint(baseConfig({ customLlmBaseUrl: "http://localhost:11434/v1" })), true);
+  assert.equal(hasCustomEndpoint(baseConfig({ customLlmApiKey: "sk-xxx" })), false);
+});
+
+test("key presence includes hasCustom", () => {
+  const presence = getLlmKeyPresence(baseConfig({ customLlmBaseUrl: "https://example.com/v1" }));
+  assert.equal(presence.hasCustom, true);
+  assert.equal(getLlmKeyPresence(baseConfig()).hasCustom, false);
+});
+
+test("wire model strips only the custom/ routing prefix", () => {
+  assert.equal(wireModelForCustomEndpoint("custom/qwen3-coder-plus"), "qwen3-coder-plus");
+  assert.equal(wireModelForCustomEndpoint("qwen3-max"), "qwen3-max");
+  assert.equal(wireModelForCustomEndpoint("openai/gpt-4o"), "openai/gpt-4o");
+});

--- a/packages/engine/src/config.ts
+++ b/packages/engine/src/config.ts
@@ -13,6 +13,10 @@ export type EngineConfig = {
   openrouterApiKey: string;
   anthropicApiKey: string;
   geminiApiKey: string;
+  /** Base URL of a custom OpenAI-compatible endpoint (Azure, DashScope, Ollama, LiteLLM, …). Serves `custom/`-prefixed models and acts as fallback when no other provider can. */
+  customLlmBaseUrl?: string;
+  /** API key for the custom endpoint. Optional — some local endpoints don't require one. */
+  customLlmApiKey?: string;
   agentModel: string;
   /** Text/JSON auxiliary work: crawl, path plans, memory curation, intents, summarization — not the main browser agent. */
   auxiliaryModel: string;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -50,6 +50,8 @@ export {
   isModelRunnableWithConfig,
   modelUnavailableReason,
   getLlmKeyPresence,
+  hasCustomEndpoint,
+  CUSTOM_MODEL_PREFIX,
 } from "./llmProviders.js";
 export type { DirectModelProvider, ModelProviderRequirement } from "./llmProviders.js";
 

--- a/packages/engine/src/llmClient.ts
+++ b/packages/engine/src/llmClient.ts
@@ -2,10 +2,12 @@ import { getConfig, type ModelConfigKey } from "./config.js";
 import { logger } from "./logger.js";
 import { anthropicMessagesChat } from "./llmAnthropic.js";
 import { llmGeminiChat } from "./llmGemini.js";
+import { llmCustomChat } from "./llmCustom.js";
 import { llmOpenAIChat, OPENAI_API_BASE } from "./llmOpenAI.js";
 import { llmOpenRouterChat } from "./llmOpenRouter.js";
 import {
   inferModelProviderRequirement,
+  hasCustomEndpoint,
   hasDirectProviderKey,
   modelUnavailableReason,
 } from "./llmProviders.js";
@@ -20,19 +22,29 @@ type LlmRoute =
   | { kind: "anthropic" }
   | { kind: "gemini" }
   | { kind: "openrouter" }
+  | { kind: "custom" }
   | { kind: "none"; reason: string };
 
-/** Prefer the matching direct provider when its key is set; otherwise OpenRouter if configured. */
+/**
+ * Prefer the matching direct provider when its key is set; otherwise OpenRouter, then the
+ * custom OpenAI-compatible endpoint. `custom/`-prefixed models always use the custom endpoint.
+ */
 function pickLlmRoute(model: string, cfg: ReturnType<typeof getConfig>): LlmRoute {
   const req = inferModelProviderRequirement(model);
+  if (req.kind === "custom") {
+    if (hasCustomEndpoint(cfg)) return { kind: "custom" };
+    return { kind: "none", reason: `Model "${model}" requires a custom endpoint — set CUSTOM_LLM_BASE_URL.` };
+  }
   if (req.kind === "openrouter_only") {
     if (cfg.openrouterApiKey) return { kind: "openrouter" };
+    if (hasCustomEndpoint(cfg)) return { kind: "custom" };
     return { kind: "none", reason: req.hint ?? `Model "${model}" requires OPENROUTER_API_KEY.` };
   }
   if (hasDirectProviderKey(cfg, req.provider)) {
     return { kind: req.provider };
   }
   if (cfg.openrouterApiKey) return { kind: "openrouter" };
+  if (hasCustomEndpoint(cfg)) return { kind: "custom" };
   return {
     kind: "none",
     reason:
@@ -260,9 +272,11 @@ const OPENROUTER_ANTHROPIC_STRUCTURED_MODELS = new Set([
  *   (OpenRouter translates this to Anthropic tool calls internally)
  * - Anthropic via OpenRouter, unsupported models (e.g. haiku-4.5) → no schema
  *   (prompt-based JSON enforcement handles format correctness)
+ * - Custom endpoint → OpenAI json_schema (dropped at runtime if the endpoint rejects it)
  * - Gemini → Gemini json_schema
  */
 function getAgentSchema(model: string, routeKind: LlmRoute["kind"]): any | undefined {
+  if (routeKind === "custom") return OPENAI_AGENT_SCHEMA;
   if (isAnthropicModel(model)) {
     if (routeKind === "anthropic") return ANTHROPIC_AGENT_SCHEMA;
     if (routeKind === "openrouter" && OPENROUTER_ANTHROPIC_STRUCTURED_MODELS.has(model)) return OPENAI_AGENT_SCHEMA;
@@ -434,6 +448,7 @@ export function getReviewBugsResponseFormat(model: string, bugTypeEnum: string[]
   const cfg = getConfig();
   const route = pickLlmRoute(model, cfg);
   if (route.kind === "none") return undefined;
+  if (route.kind === "custom") return makeBugsResponseFormat(bugTypeEnum, "oai");
   if (isAnthropicModel(model)) {
     if (route.kind === "anthropic") return makeBugsResponseFormat(bugTypeEnum, "oai");
     if (route.kind === "openrouter" && OPENROUTER_ANTHROPIC_STRUCTURED_MODELS.has(model)) {
@@ -453,6 +468,7 @@ export function getTriageResponseFormat(model: string): any | undefined {
   const cfg = getConfig();
   const route = pickLlmRoute(model, cfg);
   if (route.kind === "none") return undefined;
+  if (route.kind === "custom") return TRIAGE_RESPONSE_FORMAT_OAI;
   if (isAnthropicModel(model)) {
     if (route.kind === "anthropic") return TRIAGE_RESPONSE_FORMAT_OAI;
     if (route.kind === "openrouter" && OPENROUTER_ANTHROPIC_STRUCTURED_MODELS.has(model)) {
@@ -520,6 +536,8 @@ export function calcCostUsd(
     const p = cfg.modelPriceUsdPerMillion[slot]!;
     return (inputTokens / 1_000_000) * p.input + (outputTokens / 1_000_000) * p.output;
   }
+  // Custom-endpoint models have unknown pricing — report $0 unless the user set custom rates.
+  if (model.startsWith("custom/")) return 0;
   const key = Object.keys(MODEL_PRICING)
     .filter((k) => model.startsWith(k) || model === k)
     .sort((a, b) => b.length - a.length)[0] ?? "anthropic/claude-haiku-4.5";
@@ -563,6 +581,9 @@ export async function llmChat(
         break;
       case "openrouter":
         result = await llmOpenRouterChat(messages, model, config.openrouterApiKey!, { ...opts, timeoutMs });
+        break;
+      case "custom":
+        result = await llmCustomChat(messages, model, { ...opts, timeoutMs });
         break;
     }
 

--- a/packages/engine/src/llmCustom.ts
+++ b/packages/engine/src/llmCustom.ts
@@ -1,0 +1,28 @@
+import type OpenAI from "openai";
+import { getConfig } from "./config.js";
+import { openAIStyleChat } from "./llmOpenAICompatible.js";
+import { wireModelForCustomEndpoint } from "./llmProviders.js";
+import type { LLMUsage, LlmChatOpts } from "./llmTypes.js";
+
+/** The OpenAI SDK rejects an empty apiKey; local endpoints (Ollama, LM Studio) accept any value. */
+const NO_KEY_PLACEHOLDER = "sk-no-key";
+
+/** Chat via the user-configured OpenAI-compatible endpoint (Azure, DashScope, Ollama, LiteLLM, …). */
+export async function llmCustomChat(
+  messages: unknown[],
+  model: string,
+  opts: LlmChatOpts = {}
+): Promise<{ content: string; usage: LLMUsage }> {
+  const cfg = getConfig();
+  if (!cfg.customLlmBaseUrl) {
+    throw new Error("Custom LLM endpoint not configured — set CUSTOM_LLM_BASE_URL or add one in Settings");
+  }
+  return openAIStyleChat(
+    cfg.customLlmApiKey || NO_KEY_PLACEHOLDER,
+    cfg.customLlmBaseUrl,
+    {},
+    wireModelForCustomEndpoint(model),
+    messages as OpenAI.Chat.ChatCompletionMessageParam[],
+    opts
+  );
+}

--- a/packages/engine/src/llmOpenAICompatible.ts
+++ b/packages/engine/src/llmOpenAICompatible.ts
@@ -9,6 +9,9 @@ const MODELS_REJECTING_TEMPERATURE = new Set<string>();
 /** Completion-token ceilings discovered from 400s ("supports at most N completion tokens"). */
 const MODEL_COMPLETION_TOKEN_CAPS = new Map<string, number>();
 
+/** Models observed to reject response_format (many custom OpenAI-compatible endpoints lack json_schema support). */
+const MODELS_REJECTING_RESPONSE_FORMAT = new Set<string>();
+
 const KNOWN_COMPLETION_TOKEN_CAPS: Record<string, number> = {
   "gpt-4.1": 32768,
   "gpt-4.1-mini": 32768,
@@ -56,7 +59,9 @@ export async function openAIStyleChat(
   if (!MODELS_REJECTING_TEMPERATURE.has(wireModel)) {
     body.temperature = opts.temperature ?? 0.1;
   }
-  if (opts.responseFormat) body.response_format = opts.responseFormat;
+  if (opts.responseFormat && !MODELS_REJECTING_RESPONSE_FORMAT.has(wireModel)) {
+    body.response_format = opts.responseFormat;
+  }
   if (extra?.bodyExtensions) Object.assign(body, extra.bodyExtensions);
 
   // Newer model families (gpt-5.6, reasoning models) accept only the default
@@ -79,6 +84,12 @@ export async function openAIStyleChat(
         logger.info({ model: wireModel }, "Model rejects custom temperature — retrying without it and remembering for this model");
         MODELS_REJECTING_TEMPERATURE.add(wireModel);
         delete body.temperature;
+        continue;
+      }
+      if (/response_format|json_schema|structured output/i.test(message) && "response_format" in body) {
+        logger.info({ model: wireModel }, "Model rejects response_format — retrying without it and remembering for this model (prompt-based JSON enforcement takes over)");
+        MODELS_REJECTING_RESPONSE_FORMAT.add(wireModel);
+        delete body.response_format;
         continue;
       }
       const capMatch = message.match(/supports at most (\d+) completion tokens/i);

--- a/packages/engine/src/llmProviders.ts
+++ b/packages/engine/src/llmProviders.ts
@@ -5,18 +5,30 @@ export type DirectModelProvider = "openai" | "anthropic" | "gemini";
 
 export type ModelProviderRequirement =
   | { kind: "direct"; provider: DirectModelProvider }
+  | { kind: "custom" }
   | { kind: "openrouter_only"; hint: string };
 
 const OPENROUTER_ONLY_PREFIXES = ["deepseek/", "meta/", "mistral/", "cohere/", "perplexity/", "qwen/"];
 
+/** Model ids with this prefix always route to the custom OpenAI-compatible endpoint. */
+export const CUSTOM_MODEL_PREFIX = "custom/";
+
+/** True when a custom OpenAI-compatible endpoint is configured (API key optional). */
+export function hasCustomEndpoint(cfg: EngineConfig): boolean {
+  return !!cfg.customLlmBaseUrl;
+}
+
 /**
- * Classify which direct provider matches `model`. OpenRouter can still satisfy the call
- * when the matching direct key is missing (see `isModelRunnableWithConfig`).
+ * Classify which direct provider matches `model`. OpenRouter or a custom endpoint can
+ * still satisfy the call when the matching direct key is missing (see `isModelRunnableWithConfig`).
  */
 export function inferModelProviderRequirement(model: string): ModelProviderRequirement {
   const m = model.trim();
   if (!m) return { kind: "openrouter_only", hint: "Empty model id" };
 
+  if (m.startsWith(CUSTOM_MODEL_PREFIX)) {
+    return { kind: "custom" };
+  }
   if (m.startsWith("openai/") || m.startsWith("gpt-")) {
     return { kind: "direct", provider: "openai" };
   }
@@ -50,14 +62,18 @@ export function hasDirectProviderKey(cfg: EngineConfig, provider: DirectModelPro
 /** True if the engine can run API calls for this model id with the given config. */
 export function isModelRunnableWithConfig(model: string, cfg: EngineConfig): boolean {
   const req = inferModelProviderRequirement(model);
-  if (req.kind === "openrouter_only") return !!cfg.openrouterApiKey;
-  return hasDirectProviderKey(cfg, req.provider) || !!cfg.openrouterApiKey;
+  if (req.kind === "custom") return hasCustomEndpoint(cfg);
+  if (req.kind === "openrouter_only") return !!cfg.openrouterApiKey || hasCustomEndpoint(cfg);
+  return hasDirectProviderKey(cfg, req.provider) || !!cfg.openrouterApiKey || hasCustomEndpoint(cfg);
 }
 
 /** Human-readable reason when `isModelRunnableWithConfig` is false (no secrets). */
 export function modelUnavailableReason(model: string, cfg: EngineConfig): string | null {
   if (isModelRunnableWithConfig(model, cfg)) return null;
   const req = inferModelProviderRequirement(model);
+  if (req.kind === "custom") {
+    return "Models with a custom/ prefix require a custom endpoint — set CUSTOM_LLM_BASE_URL";
+  }
   if (req.kind === "openrouter_only") {
     return req.hint ?? "Configure OPENROUTER_API_KEY for this model";
   }
@@ -67,7 +83,7 @@ export function modelUnavailableReason(model: string, cfg: EngineConfig): string
       : req.provider === "anthropic"
         ? "ANTHROPIC_API_KEY"
         : "GEMINI_API_KEY";
-  return `Missing ${keyName} or OPENROUTER_API_KEY`;
+  return `Missing ${keyName}, OPENROUTER_API_KEY, or CUSTOM_LLM_BASE_URL`;
 }
 
 /** Which provider API keys are present (for Settings UI). Never exposes key values. */
@@ -76,12 +92,14 @@ export function getLlmKeyPresence(cfg: EngineConfig): {
   hasOpenAI: boolean;
   hasAnthropic: boolean;
   hasGemini: boolean;
+  hasCustom: boolean;
 } {
   return {
     hasOpenRouter: !!cfg.openrouterApiKey,
     hasOpenAI: !!cfg.openaiApiKey,
     hasAnthropic: !!cfg.anthropicApiKey,
     hasGemini: !!cfg.geminiApiKey,
+    hasCustom: hasCustomEndpoint(cfg),
   };
 }
 
@@ -93,5 +111,11 @@ export function wireModelForOpenAIDirect(model: string): string {
 /** Google AI Studio OpenAI-compatible API uses plain Gemini model ids (no google/ prefix). */
 export function wireModelForGeminiDirect(model: string): string {
   if (model.startsWith("google/")) return model.slice("google/".length);
+  return model;
+}
+
+/** Custom endpoints receive the model id verbatim, minus the routing-only custom/ prefix. */
+export function wireModelForCustomEndpoint(model: string): string {
+  if (model.startsWith(CUSTOM_MODEL_PREFIX)) return model.slice(CUSTOM_MODEL_PREFIX.length);
   return model;
 }

--- a/packages/engine/src/stagehandBridge.ts
+++ b/packages/engine/src/stagehandBridge.ts
@@ -7,7 +7,12 @@ import { logger } from "./logger.js";
 import { dockerHostResolverArgs } from "./dockerHost.js";
 import { screenshotDpr } from "./screenshotConfig.js";
 import { OPENROUTER_BASE } from "./llmOpenRouter.js";
-import { hasDirectProviderKey, inferModelProviderRequirement } from "./llmProviders.js";
+import {
+  CUSTOM_MODEL_PREFIX,
+  hasDirectProviderKey,
+  inferModelProviderRequirement,
+  wireModelForCustomEndpoint,
+} from "./llmProviders.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -38,7 +43,7 @@ type StagehandModelConfig = {
 
 function directStagehandApiKey(cfg: EngineConfig, model: string): string | null {
   const req = inferModelProviderRequirement(model);
-  if (req.kind === "openrouter_only") return null;
+  if (req.kind !== "direct") return null;
   if (!hasDirectProviderKey(cfg, req.provider)) return null;
   switch (req.provider) {
     case "openai":
@@ -69,7 +74,25 @@ function toOpenRouterModelId(model: string): string {
   return m;
 }
 
+function customEndpointStagehandConfig(cfg: EngineConfig, model: string): StagehandModelConfig {
+  return {
+    // Stagehand's AI SDK route uses the first path segment as the provider; `openai/`
+    // sends the call through its OpenAI-compatible client against the custom base URL.
+    modelName: `openai/${wireModelForCustomEndpoint(model)}`,
+    modelClientOptions: {
+      apiKey: cfg.customLlmApiKey || "sk-no-key",
+      baseURL: cfg.customLlmBaseUrl,
+      compatibility: "compatible",
+    },
+    routedViaOpenRouter: false,
+  };
+}
+
 function resolveStagehandModelConfig(cfg: EngineConfig, configuredModel: string): StagehandModelConfig {
+  if (configuredModel.trim().startsWith(CUSTOM_MODEL_PREFIX) && cfg.customLlmBaseUrl) {
+    return customEndpointStagehandConfig(cfg, configuredModel.trim());
+  }
+
   const apiKey = directStagehandApiKey(cfg, configuredModel);
   if (apiKey) {
     return {
@@ -96,6 +119,10 @@ function resolveStagehandModelConfig(cfg: EngineConfig, configuredModel: string)
       },
       routedViaOpenRouter: true,
     };
+  }
+
+  if (cfg.customLlmBaseUrl) {
+    return customEndpointStagehandConfig(cfg, configuredModel.trim());
   }
 
   return {

--- a/packages/mcp/src/tools/settings.ts
+++ b/packages/mcp/src/tools/settings.ts
@@ -14,7 +14,7 @@ WHEN TO USE:
 
 Returns:
   • Model slots (agentModel, auxiliaryModel, reviewAgentModel, stagehandModel) — current values and whether they are customized
-  • API key status for each provider (openai, anthropic, gemini, openrouter) — whether a key is set and its source (env var or DB override). Key values are never returned, only a masked hint.
+  • API key status for each provider (openai, anthropic, gemini, openrouter, custom) — whether a key is set and its source (env var or DB override). Key values are never returned, only a masked hint. The custom provider is an OpenAI-compatible endpoint (base URL + optional key).
   • Whether each model can run with the current key configuration`,
     {},
     async () => {
@@ -30,7 +30,8 @@ Returns:
       const apiKeys = await client.getApiKeys();
 
       const missingKeys = Object.entries(apiKeys)
-        .filter(([, v]) => !(v as any).hasKey)
+        // The custom endpoint is optional and defined by its base URL, not a key.
+        .filter(([k, v]) => k !== "custom" && !(v as any).hasKey)
         .map(([k]) => k);
 
       return {
@@ -74,6 +75,7 @@ API KEY PROVIDERS (at least one required):
   'openai'      — direct OpenAI access
   'anthropic'   — direct Anthropic access
   'gemini'      — direct Google Gemini access
+  'custom'      — any OpenAI-compatible endpoint (Azure, DashScope, Ollama, LiteLLM…). Set customBaseUrl (required) and optionally a key. Use model ids prefixed 'custom/', e.g. 'custom/qwen3-coder-plus'.
 
 VALIDATION:
   • Model names must be valid for an available provider (e.g. 'anthropic/claude-sonnet-5', 'openai/gpt-5.6-terra', 'google/gemini-3.5-flash')
@@ -131,6 +133,14 @@ VALIDATION:
             .string()
             .optional()
             .describe("OpenRouter API key (starts with 'sk-or-'). Pass empty string to clear."),
+          custom: z
+            .string()
+            .optional()
+            .describe("API key for the custom OpenAI-compatible endpoint (optional — some local endpoints need none). Pass empty string to clear."),
+          customBaseUrl: z
+            .string()
+            .optional()
+            .describe("Base URL of the custom OpenAI-compatible endpoint, e.g. 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'. Pass empty string to clear."),
         })
         .optional()
         .describe("API keys to save. Values are encrypted at rest and never returned in API responses."),


### PR DESCRIPTION
Lets users bring their own OpenAI-compatible endpoint (Azure, Alibaba DashScope, Ollama, LiteLLM, …) instead of needing an OpenAI / Anthropic / Gemini / OpenRouter key. Requested by a community member on Discord.

## How it works

- **Config**: `CUSTOM_LLM_BASE_URL` + optional `CUSTOM_LLM_API_KEY` env vars, or Settings → API Keys → "Custom endpoint" card in the dashboard (key stored encrypted, base URL plain).
- **Routing**: model ids prefixed `custom/` (e.g. `custom/qwen3-coder-plus`) always route to the custom endpoint with the prefix stripped; unprefixed models fall back to it when no direct provider key or OpenRouter can serve them.
- **Robustness**: endpoints that reject `response_format` are discovered at runtime and remembered per model (same pattern as the existing temperature / completion-cap discovery); prompt-based JSON enforcement takes over.
- **Coverage**: engine chat routing, Stagehand element finding, Settings UI (endpoint card + custom-model provider option), API settings routes, MCP settings tools, client SDK, docker-compose/env docs.
- **Cost**: custom models report $0 unless per-slot rates are configured.

## Testing

- 7 new unit tests in `packages/engine/src/__tests__/llmProviders.test.ts` (48/48 engine tests pass, all workspaces build).
- Verified end-to-end locally against a mock OpenAI-compatible server: prefix routing, fallback routing, auth header, usage parsing, and the full Settings UI flow (save endpoint → pick `custom/` model → validation passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
