### PR TITLE
chore(release): bump @keryai/client 0.1.1, @keryai/mcp 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12672,7 +12672,7 @@
     },
     "packages/client": {
       "name": "@keryai/client",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -12801,7 +12801,7 @@
     },
     "packages/mcp": {
       "name": "@keryai/mcp",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@keryai/client": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keryai/client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Typed HTTP client for the Kery AI testing API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keryai/mcp",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Kery MCP server — lets AI agents in your IDE run browser tests via Kery",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bumps for the v0.4.0 release (custom OpenAI-compatible endpoint support, #23). `keryai` is unchanged — its publish job will skip idempotently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)